### PR TITLE
add ip address information to ec2 instance

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -231,6 +231,8 @@ type Instance struct {
 	ImageId            string        `xml:"imageId"`
 	PrivateDNSName     string        `xml:"privateDnsName"`
 	DNSName            string        `xml:"dnsName"`
+	IpAddress          string        `xml:"ipAddress"`
+	PrivateIpAddress   string        `xml:"privateIpAddress"`
 	KeyName            string        `xml:"keyName"`
 	AMILaunchIndex     int           `xml:"amiLaunchIndex"`
 	Hypervisor         string        `xml:"hypervisor"`


### PR DESCRIPTION
Currently the Instance struct does not include the public and private ip address of the instances, this patch makes these fields of the [RunningInstancesItemType](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-ItemType-RunningInstancesItemType.html) available
