### PR TITLE
added x-amz-security-token to presigned urls for s3

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -493,7 +493,11 @@ func (b *Bucket) SignedURL(path string, expires time.Time) string {
 	if err != nil {
 		panic(err)
 	}
+	if s3.Auth.SecurityToken != "" {
+		return u.String() + "&x-amz-security-token=" + url.QueryEscape(req.headers["X-Amz-Security-Token"][0])
+	} else {
 	return u.String()
+	}
 }
 
 type request struct {


### PR DESCRIPTION
When you are using temporary credentials like ones you get using IAM roles, you need to pass your security token in the query string as well as the key and signature when you create a presigned URL for s3 objects.
