### PR TITLE
Get auth needs to accept and return token as well as accesskey, secret key

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -260,10 +260,10 @@ func getInstanceCredentials() (cred credentials, err error) {
 
 // GetAuth creates an Auth based on either passed in credentials,
 // environment information or instance based role credentials.
-func GetAuth(accessKey string, secretKey string) (auth Auth, err error) {
+func GetAuth(accessKey string, secretKey, token string) (auth Auth, err error) {
 	// First try passed in credentials
 	if accessKey != "" && secretKey != "" {
-		return Auth{accessKey, secretKey, ""}, nil
+		return Auth{accessKey, secretKey, token}, nil
 	}
 
 	// Next try to get auth from the environment


### PR DESCRIPTION
I use GetAuth like this:

```
auth, err := aws.GetAuth(_ServerAuth.AccessKey, _ServerAuth.SecretKey)
if err != nil {
        log.Printf("something horrible happened here")
    }
```

in this scenario, I need GetAuth to accept and return the token in case I've had a temporary token already, I want to keep it,
