### PR TITLE
Fix behaviour of DeleteItem.

### DIFF
--- a/dynamodb/item.go
+++ b/dynamodb/item.go
@@ -126,25 +126,12 @@ func (t *Table) PutItem(hashKey string, rangeKey string, attributes []Attribute)
 	return true, nil
 }
 
-func (t *Table) AddItem(key *Key, attributes []Attribute) (bool, error) {
-	return t.modifyItem(key, attributes, "ADD")
-}
-
-func (t *Table) UpdateItem(key *Key, attributes []Attribute) (bool, error) {
-	return t.modifyItem(key, attributes, "PUT")
-}
-
-func (t *Table) modifyItem(key *Key, attributes []Attribute, action string) (bool, error) {
-
-	if len(attributes) == 0 {
-		return false, errors.New("At least one attribute is required.")
-	}
+func (t *Table) DeleteItem(key *Key) (bool, error) {
 
 	q := NewQuery(t)
 	q.AddKey(t, key)
-	q.AddUpdates(attributes, action)
 
-	jsonResponse, err := t.Server.queryServer(target("UpdateItem"), q)
+	jsonResponse, err := t.Server.queryServer(target("DeleteItem"), q)
 
 	if err != nil {
 		return false, err
@@ -158,12 +145,29 @@ func (t *Table) modifyItem(key *Key, attributes []Attribute, action string) (boo
 	return true, nil
 }
 
-func (t *Table) DeleteItem(key *Key) (bool, error) {
+func (t *Table) AddAttributes(key *Key, attributes []Attribute) (bool, error) {
+	return t.modifyAttributes(key, attributes, "ADD")
+}
+
+func (t *Table) UpdateAttributes(key *Key, attributes []Attribute) (bool, error) {
+	return t.modifyAttributes(key, attributes, "PUT")
+}
+
+func (t *Table) DeleteAttributes(key *Key, attributes []Attribute) (bool, error) {
+	return t.modifyAttributes(key, attributes, "DELETE")
+}
+
+func (t *Table) modifyAttributes(key *Key, attributes []Attribute, action string) (bool, error) {
+
+	if len(attributes) == 0 {
+		return false, errors.New("At least one attribute is required.")
+	}
 
 	q := NewQuery(t)
 	q.AddKey(t, key)
+	q.AddUpdates(attributes, action)
 
-	jsonResponse, err := t.Server.queryServer(target("DeleteItem"), q)
+	jsonResponse, err := t.Server.queryServer(target("UpdateItem"), q)
 
 	if err != nil {
 		return false, err


### PR DESCRIPTION
The current behaviour makes DeleteItem behave like UpdateItem
using the "Delete" action. This actually does not delete an item
but an attribute.

See http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html

This patch makes DeleteItem deleting items using the DeleteItem api
method.

See http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteItem.html
