### PR TITLE
fix xml tags in sqs Attribute type. add tests to deep compare attributes

### DIFF
--- a/sqs/responses_test.go
+++ b/sqs/responses_test.go
@@ -117,3 +117,49 @@ var TestDeleteMessageBatchXmlOK = `
     </ResponseMetadata>
 </DeleteMessageBatchResponse>
 `
+
+var TestGetQueueAttributesXmlOK = `
+<GetQueueAttributesResponse>
+  <GetQueueAttributesResult>
+    <Attribute>
+      <Name>ReceiveMessageWaitTimeSeconds</Name>
+      <Value>2</Value>
+    </Attribute>
+    <Attribute>
+      <Name>VisibilityTimeout</Name>
+      <Value>30</Value>
+    </Attribute>
+    <Attribute>
+      <Name>ApproximateNumberOfMessages</Name>
+      <Value>0</Value>
+    </Attribute>
+    <Attribute>
+      <Name>ApproximateNumberOfMessagesNotVisible</Name>
+      <Value>0</Value>
+    </Attribute>
+    <Attribute>
+      <Name>CreatedTimestamp</Name>
+      <Value>1286771522</Value>
+    </Attribute>
+    <Attribute>
+      <Name>LastModifiedTimestamp</Name>
+      <Value>1286771522</Value>
+    </Attribute>
+    <Attribute>
+      <Name>QueueArn</Name>
+      <Value>arn:aws:sqs:us-east-1:123456789012:qfoo</Value>
+    </Attribute>
+    <Attribute>
+      <Name>MaximumMessageSize</Name>
+      <Value>8192</Value>
+    </Attribute>
+    <Attribute>
+      <Name>MessageRetentionPeriod</Name>
+      <Value>345600</Value>
+    </Attribute>
+  </GetQueueAttributesResult>
+  <ResponseMetadata>
+    <RequestId>1ea71be5-b5a2-4f9d-b85a-945d8d08cd0b</RequestId>
+  </ResponseMetadata>
+</GetQueueAttributesResponse>
+`

--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -107,8 +107,8 @@ type Message struct {
 }
 
 type Attribute struct {
-	Name  string `xml:"ReceiveMessageResult>Message>Attribute>Name"`
-	Value string `xml:"ReceiveMessageResult>Message>Attribute>Value"`
+	Name  string `xml:"Name"`
+	Value string `xml:"Value"`
 }
 
 type ChangeMessageVisibilityResponse struct {


### PR DESCRIPTION
Getting queue attributes wasn't unmarshaling correctly. I also added in a test for `GetQueueAttributes` and deep comparing attribute slices.

Thanks!!
