### PR TITLE
detect 'missing item' in GetItem and flag it as a specific error condition

### DIFF
--- a/dynamodb/dynamodb.go
+++ b/dynamodb/dynamodb.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 	"log"
+	"errors"
 )
 
 type Server struct {
@@ -28,6 +29,9 @@ func NewQuery(queryParts []string) *Query {
 	}
 }
 */
+
+// Specific error constants
+var ErrNotFound = errors.New("Item not found")
 
 // Error represents an error in an operation with Dynamodb (following goamz/s3)
 type Error struct {

--- a/dynamodb/item.go
+++ b/dynamodb/item.go
@@ -78,19 +78,22 @@ func (t *Table) GetItem(key *Key) (map[string]*Attribute, error) {
 	q.AddKey(t, key)
 
 	jsonResponse, err := t.Server.queryServer(target("GetItem"), q)
-
 	if err != nil {
 		return nil, err
 	}
 
 	json, err := simplejson.NewJson(jsonResponse)
-
 	if err != nil {
 		return nil, err
 	}
 
-	item, err := json.Get("Item").Map()
-
+	itemJson, ok := json.CheckGet("Item")
+	if !ok {
+		// We got an empty from amz. The item doesn't exist.
+		return nil, ErrNotFound
+	}
+	
+	item, err := itemJson.Map()
 	if err != nil {
 		message := fmt.Sprintf("Unexpected response %s", jsonResponse)
 		return nil, errors.New(message)


### PR DESCRIPTION
The code currently returns a generic json parsing error ("unexpected response") if it gets back json of "{}", which corresponds to "item not found".

With this change, the caller can test for this case with code structured like:

item, err := t.GetItem(...)
if err == dynamodb.ErrNotFound {
  // no item matches the key, that's ok, but note item will be nil
} else {
  if err != nil {
    // Some error occurred, inspect err.Error()
  } else {
    // Item will be non-nil, let's use it
  }
}
