### PR TITLE
Switch to using the built-in encoding/json marshaller for query building (work done by Mark Boyd)

### DIFF
--- a/dynamodb/query_builder.go
+++ b/dynamodb/query_builder.go
@@ -1,23 +1,21 @@
 package dynamodb
 
 import (
-	"bytes"
-	"fmt"
+	"encoding/json"
 	"strconv"
 )
 
+type msi map[string]interface{}
 type Query struct {
-	buffer *bytes.Buffer
+	buffer msi
 }
 
 func NewEmptyQuery() *Query {
-	q := &Query{new(bytes.Buffer)}
-	q.buffer.WriteString("")
-	return q
+	return &Query{msi{}}
 }
 
 func NewQuery(t *Table) *Query {
-	q := &Query{new(bytes.Buffer)}
+	q := &Query{msi{}}
 	q.addTable(t)
 	return q
 }
@@ -25,272 +23,107 @@ func NewQuery(t *Table) *Query {
 // This way of specifing the key is used when doing a Get.
 // If rangeKey is "", it is assumed to not want to be used
 func (q *Query) AddKey(t *Table, key *Key) {
-	b := q.buffer
 	k := t.Key
-
-	addComma(b)
-
-	b.WriteString(quote("Key"))
-	b.WriteString(":")
-
-	b.WriteString("{")
-	b.WriteString(quote(k.KeyAttribute.Name))
-	b.WriteString(":")
-
-	b.WriteString("{")
-	b.WriteString(quote(k.KeyAttribute.Type))
-	b.WriteString(":")
-	b.WriteString(quote(key.HashKey))
-
-	b.WriteString("}")
-
+	keymap := msi{
+		k.KeyAttribute.Name: msi{
+			k.KeyAttribute.Type: key.HashKey},
+	}
 	if k.HasRange() {
-		b.WriteString(",")
-		b.WriteString(quote(k.RangeAttribute.Name))
-		b.WriteString(":")
-
-		b.WriteString("{")
-		b.WriteString(quote(k.RangeAttribute.Type))
-		b.WriteString(":")
-		b.WriteString(quote(key.RangeKey))
-		b.WriteString("}")
+		keymap[k.RangeAttribute.Name] = msi{k.RangeAttribute.Type: key.RangeKey}
 	}
 
-	b.WriteString("}")
+	q.buffer["Key"] = keymap
 }
 
-func (q *Query) addKeyAttributes(t *Table, key *Key) {
-	b := q.buffer
+func keyAttributes(t *Table, key *Key) msi {
 	k := t.Key
 
-	b.WriteString("{")
-	b.WriteString(quote(k.KeyAttribute.Name))
-	b.WriteString(":")
-
-	b.WriteString("{")
-	b.WriteString(quote(k.KeyAttribute.Type))
-	b.WriteString(":")
-	b.WriteString(quote(key.HashKey))
-
-	b.WriteString("}")
-
+	out := msi{}
+	out[k.KeyAttribute.Name] = msi{k.KeyAttribute.Type: key.HashKey}
 	if k.HasRange() {
-		b.WriteString(",")
-		b.WriteString(quote(k.RangeAttribute.Name))
-		b.WriteString(":")
-
-		b.WriteString("{")
-		b.WriteString(quote(k.RangeAttribute.Type))
-		b.WriteString(":")
-		b.WriteString(quote(key.RangeKey))
-		b.WriteString("}")
+		out[k.RangeAttribute.Name] = msi{k.RangeAttribute.Type: key.RangeKey}
 	}
-
-	b.WriteString("}")
+	return out
 }
 
 func (q *Query) AddAttributesToGet(attributes []string) {
 	if len(attributes) == 0 {
 		return
 	}
-	b := q.buffer
-	addComma(b)
 
-	b.WriteString(quote("AttributesToGet"))
-	b.WriteString(":")
-
-	b.WriteString("[")
-
-	for index, val := range attributes {
-		if index > 0 {
-			b.WriteString(",")
-		}
-		b.WriteString(quote(val))
-	}
-
-	b.WriteString("]")
+	q.buffer["AttributesToGet"] = attributes
 }
 
 func (q *Query) ConsistentRead(c bool) {
 	if c == true {
-		b := q.buffer
-		addComma(b)
-
-		b.WriteString(quote("ConsistentRead"))
-		b.WriteString(":")
-		b.WriteString("true")
+		q.buffer["ConsistentRead"] = "true" //String "true", not bool true
 	}
 }
 
 func (q *Query) AddGetRequestItems(tableKeys map[*Table][]Key) {
-	b := q.buffer
-
-	b.WriteString(quote("RequestItems"))
-	b.WriteString(":")
-	b.WriteString("{")
-
-	firstItem := true
+	requestitems := msi{}
 	for table, keys := range tableKeys {
-		if !firstItem {
-			b.WriteString(",")
-		} else {
-			firstItem = false
+		keyslist := []msi{}
+		for _, key := range keys {
+			keyslist = append(keyslist, keyAttributes(table, &key))
 		}
-
-		b.WriteString(quote(table.Name))
-		b.WriteString(":")
-		b.WriteString("{")
-
-		b.WriteString(quote("Keys"))
-		b.WriteString(":")
-		b.WriteString("[")
-		for index, key := range keys {
-			if index > 0 {
-				b.WriteString(",")
-			}
-			q.addKeyAttributes(table, &key)
-		}
-		b.WriteString("]")
-
-		b.WriteString("}")
+		requestitems[table.Name] = msi{"Keys": keyslist}
 	}
-	b.WriteString("}")
+	q.buffer["RequestItems"] = requestitems
 }
 
 func (q *Query) AddWriteRequestItems(tableItems map[*Table]map[string][][]Attribute) {
 	b := q.buffer
 
-	b.WriteString(quote("RequestItems"))
-	b.WriteString(":")
-	b.WriteString("{")
-
-	countTable := 0
-	for table, itemActions := range tableItems {
-		if countTable != 0 {
-			b.WriteString(",")
-		}
-		countTable++
-
-		b.WriteString(quote(table.Name))
-		b.WriteString(":")
-		b.WriteString("[")
-
-		countAction := 0
-		for action, items := range itemActions {
-			if countAction != 0 {
-				b.WriteString(",")
-			}
-			countAction++
-			for index, attributes := range items {
-				if index != 0 {
-					b.WriteString(",")
+	b["RequestItems"] = func() msi {
+		out := msi{}
+		for table, itemActions := range tableItems {
+			out[table.Name] = func() interface{} {
+				out2 := []interface{}{}
+				for action, items := range itemActions {
+					for _, attributes := range items {
+						Item_or_Key := map[bool]string{true: "Item", false: "Key"}[action == "Put"]
+						out2 = append(out2, msi{action + "Request": msi{Item_or_Key: attributeList(attributes)}})
+					}
 				}
-
-				b.WriteString("{")
-				b.WriteString(quote(action+"Request"))
-				b.WriteString(":")
-				b.WriteString("{")
-
-				if action == "Put" {
-					b.WriteString(quote("Item"))
-				} else {
-					b.WriteString(quote("Key"))
-				}
-				b.WriteString(":")
-				attributeList(b, attributes)
-
-				b.WriteString("}")
-				b.WriteString("}")
-			}
+				return out2
+			}()
 		}
-
-		b.WriteString("]")
-	}
-	b.WriteString("}")
+		return out
+	}()
 }
 
 func (q *Query) AddCreateRequestTable(description TableDescriptionT) {
 	b := q.buffer
 
-	b.WriteString(quote("AttributeDefinitions"))
-	b.WriteString(":")
-	b.WriteString("[")
-	for i, attr := range description.AttributeDefinitions {
-		if i != 0 {
-			b.WriteString(",")
-		}
-
-		b.WriteString("{")
-		b.WriteString(quote("AttributeName"))
-		b.WriteString(":")
-		b.WriteString(quote(attr.Name))
-		b.WriteString(",")
-		b.WriteString(quote("AttributeType"))
-		b.WriteString(":")
-		b.WriteString(quote(attr.Type))
-		b.WriteString("}")
+	attDefs := []interface{}{}
+	for _, attr := range description.AttributeDefinitions {
+		attDefs = append(attDefs, msi{
+			"AttributeName": attr.Name,
+			"AttributeType": attr.Type,
+		})
 	}
-	b.WriteString("]")
-	b.WriteString(",")
-
-	b.WriteString(quote("KeySchema"))
-	b.WriteString(":")
-	b.WriteString("[")
-	for i, keyS := range description.KeySchema {
-		if i != 0 {
-			b.WriteString(",")
-		}
-
-		b.WriteString("{")
-		b.WriteString(quote("AttributeName"))
-		b.WriteString(":")
-		b.WriteString(quote(keyS.AttributeName))
-		b.WriteString(",")
-		b.WriteString(quote("KeyType"))
-		b.WriteString(":")
-		b.WriteString(quote(keyS.KeyType))
-		b.WriteString("}")
+	b["AttributeDefinitions"] = attDefs
+	b["KeySchema"] = description.KeySchema
+	b["TableName"] = description.TableName
+	b["ProvisionedThroughput"] = msi{
+		"ReadCapacityUnits":  int(description.ProvisionedThroughput.ReadCapacityUnits),
+		"WriteCapacityUnits": int(description.ProvisionedThroughput.WriteCapacityUnits),
 	}
-	b.WriteString("]")
-	b.WriteString(",")
-
-	b.WriteString(quote("TableName"))
-	b.WriteString(":")
-	b.WriteString(quote(description.TableName))
-	b.WriteString(",")
-
-	b.WriteString(quote("ProvisionedThroughput"))
-	b.WriteString(":")
-	b.WriteString("{")
-	b.WriteString(quote("ReadCapacityUnits"))
-	b.WriteString(":")
-	b.WriteString(strconv.Itoa(int(description.ProvisionedThroughput.ReadCapacityUnits)))
-	b.WriteString(",")
-	b.WriteString(quote("WriteCapacityUnits"))
-	b.WriteString(":")
-	b.WriteString(strconv.Itoa(int(description.ProvisionedThroughput.WriteCapacityUnits)))
-	b.WriteString("}")
 
 	// Todo: Implement LocalSecondayIndexes
 }
 
 func (q *Query) AddKeyConditions(comparisons []AttributeComparison) {
-	b := q.buffer
-	addComma(b)
-	b.WriteString("\"KeyConditions\":{")
-	q.addComparisons(comparisons)
-	b.WriteString("}")
+	q.buffer["KeyConditions"] = buildComparisons(comparisons)
 }
 
 func (q *Query) AddLimit(limit int64) {
-	b := q.buffer
-	addComma(b)
-	q.buffer.WriteString(keyValue("Limit", strconv.FormatInt(limit, 10)))
+	//TODO: check this ... really add a string containing an int?
+	q.buffer["Limit"] = strconv.FormatInt(limit, 10)
 }
 func (q *Query) AddSelect(value string) {
-	b := q.buffer
-	addComma(b)
-	q.buffer.WriteString(keyValue("Select", value))
+	q.buffer["Select"] = value
 }
 
 /*
@@ -299,204 +132,73 @@ func (q *Query) AddSelect(value string) {
    },
 */
 func (q *Query) AddScanFilter(comparisons []AttributeComparison) {
-	b := q.buffer
-	addComma(b)
-	b.WriteString("\"ScanFilter\":{")
-	q.addComparisons(comparisons)
-	b.WriteString("}")
+	q.buffer["ScanFilter"] = buildComparisons(comparisons)
 }
 
 func (q *Query) AddParallelScanConfiguration(segment int, totalSegments int) {
-	b := q.buffer
-	addComma(b)
-	b.WriteString(fmt.Sprintf("\"Segment\":%d", segment))
-	addComma(b)
-	b.WriteString(fmt.Sprintf("\"TotalSegments\":%d", totalSegments))
+	q.buffer["Segment"] = segment
+	q.buffer["TotalSegments"] = totalSegments
 }
 
-func (q *Query) addComparisons(comparisons []AttributeComparison) {
-	b := q.buffer
-	for i, c := range comparisons {
-		if i > 0 {
-			b.WriteString(",")
-		}
+func buildComparisons(comparisons []AttributeComparison) msi {
+	out := msi{}
 
-		b.WriteString(quote(c.AttributeName))
-		b.WriteString(":{\"AttributeValueList\":[")
-		for j, attributeValue := range c.AttributeValueList {
-			if j > 0 {
-				b.WriteString(",")
-			}
-			b.WriteString("{")
-			b.WriteString(quote(attributeValue.Type))
-			b.WriteString(":")
-			b.WriteString(quote(attributeValue.Value))
-			b.WriteString("}")
+	for _, c := range comparisons {
+		avlist := []interface{}{}
+		for _, attributeValue := range c.AttributeValueList {
+			avlist = append(avlist, msi{attributeValue.Type: attributeValue.Value})
 		}
-		b.WriteString("], \"ComparisonOperator\":")
-		b.WriteString(quote(c.ComparisonOperator))
-		b.WriteString("}")
+		out[c.AttributeName] = msi{"AttributeValueList": avlist}
+		out["ComparisonOperator"] = c.ComparisonOperator
 	}
+
+	return out
 }
 
 // The primary key must be included in attributes.
 func (q *Query) AddItem(attributes []Attribute) {
-	b := q.buffer
-
-	addComma(b)
-
-	b.WriteString(quote("Item"))
-	b.WriteString(":")
-
-	attributeList(b, attributes)
+	q.buffer["Item"] = attributeList(attributes)
 }
 
 func (q *Query) AddUpdates(attributes []Attribute, action string) {
-	b := q.buffer
-
-	addComma(b)
-
-	b.WriteString(quote("AttributeUpdates"))
-	b.WriteString(":")
-
-	b.WriteString("{")
-	for index, a := range attributes {
-		if index > 0 {
-			b.WriteString(",")
-		}
-
-		b.WriteString(quote(a.Name))
-		b.WriteString(":")
-		b.WriteString("{")
-		b.WriteString(quote("Value"))
-		b.WriteString(":")
-		b.WriteString("{")
-		b.WriteString(quote(a.Type))
-		b.WriteString(":")
-
-		if a.SetType() {
-			b.WriteString("[")
-			for i, aval := range a.SetValues {
-				if i > 0 {
-					b.WriteString(",")
-				}
-				b.WriteString(quote(aval))
-			}
-			b.WriteString("]")
-		} else {
-			b.WriteString(quote(a.Value))
-		}
-
-		b.WriteString("}")
-		b.WriteString(",")
-		b.WriteString(quote("Action"))
-		b.WriteString(":")
-		b.WriteString(quote(action))
-		b.WriteString("}")
+	updates := msi{}
+	for _, a := range attributes {
+		//UGH!!  (I miss the query operator)
+		updates[a.Name] = msi{a.Type: map[bool]interface{}{true: a.SetValues, false: a.Value}[a.SetType()]}
+		updates["Action"]=action
 	}
-	b.WriteString("}")
+
+	q.buffer["AttributeUpdates"] = updates
 }
 
 func (q *Query) AddExpected(attributes []Attribute) {
-	b := q.buffer
-	addComma(b)
-
-	b.WriteString(quote("Expected"))
-	b.WriteString(":")
-	b.WriteString("{")
-
-	for index, a := range attributes {
-		if index > 0 {
-			b.WriteString(",")
-		}
-
-		b.WriteString(quote(a.Name))
-		b.WriteString(":")
-
-		b.WriteString("{")
-
+	expected := msi{}
+	for _, a := range attributes {
+		value := msi{}
 		if a.Exists != "" {
-			b.WriteString(quote("Exists"))
-			b.WriteString(":")
-			b.WriteString("{")
-			b.WriteString(quote(a.Exists))
-			b.WriteString("}")
-			b.WriteString(",")
+			value["Exists"] = a.Exists
 		}
-
-		b.WriteString(quote("Value"))
-		b.WriteString(":")
-		b.WriteString("{")
-		b.WriteString(quote(a.Type))
-		b.WriteString(":")
-
-		if a.SetType() {
-			b.WriteString("[")
-			for i, aval := range a.SetValues {
-				if i > 0 {
-					b.WriteString(",")
-				}
-				b.WriteString(quote(aval))
-			}
-			b.WriteString("]")
-		} else {
-			b.WriteString(quote(a.Value))
-		}
-
-		b.WriteString("}")
-		b.WriteString("}")
+		//UGH!!  (I miss the query operator)
+		value["Value"] = msi{a.Type: map[bool]interface{}{true: a.SetValues, false: a.Value}[a.SetType()]}
+		expected[a.Name] = value
 	}
-
-	b.WriteString("}")
+	q.buffer["Expected"] = expected
 }
 
-func attributeList(b *bytes.Buffer, attributes []Attribute) {
-	b.WriteString("{")
-	for index, a := range attributes {
-		if index > 0 {
-			b.WriteString(",")
-		}
-
-		b.WriteString(quote(a.Name))
-		b.WriteString(":")
-
-		b.WriteString("{")
-		b.WriteString(quote(a.Type))
-		b.WriteString(":")
-
-		if a.SetType() {
-			b.WriteString("[")
-			for i, aval := range a.SetValues {
-				if i > 0 {
-					b.WriteString(",")
-				}
-				b.WriteString(quote(aval))
-			}
-			b.WriteString("]")
-		} else {
-			b.WriteString(strconv.Quote(a.Value)) // this needs to be quote escaped
-		}
-
-		b.WriteString("}")
+func attributeList(attributes []Attribute) msi {
+	b := msi{}
+	for _, a := range attributes {
+		//UGH!!  (I miss the query operator)
+		b[a.Name] = msi{a.Type: map[bool]interface{}{true: a.SetValues, false: a.Value}[a.SetType()]}
 	}
-	b.WriteString("}")
+	return b
 }
 
 func (q *Query) addTable(t *Table) {
-	q.buffer.WriteString(keyValue("TableName", t.Name))
-}
-
-func quote(s string) string {
-	return fmt.Sprintf("\"%s\"", s)
-}
-
-func addComma(b *bytes.Buffer) {
-	if b.Len() != 0 {
-		b.WriteString(",")
-	}
+	q.buffer["TableName"] = t.Name
 }
 
 func (q *Query) String() string {
-	qs := fmt.Sprintf("{%s}", q.buffer.String())
-	return qs
+	bytes, _ := json.Marshal(q.buffer)
+	return string(bytes)
 }


### PR DESCRIPTION
Instead of building json by hand, use the built in json encoder.

The motivation for this was to fix a bug detected in our unit tests relating to a double-quote character in an attribute value, but as a nice side effect,  the rework also reduces amount of code significantly.
