### PR TITLE
Fix Dimensions and Stats prefixes

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -226,12 +226,12 @@ func (c *CloudWatch) PutMetricData(metrics []MetricDatum) (result *aws.BaseRespo
 			params[prefix+".Timestamp"] = metric.Timestamp.UTC().Format(time.RFC3339)
 		}
 		for j, dim := range metric.Dimensions {
-			dimprefix := prefix + "Dimensions.member." + strconv.Itoa(j+1)
+			dimprefix := prefix + ".Dimensions.member." + strconv.Itoa(j+1)
 			params[dimprefix+".Name"] = dim.Name
 			params[dimprefix+".Value"] = dim.Value
 		}
 		for j, stat := range metric.StatisticValues {
-			statprefix := prefix + "StatisticValues.member." + strconv.Itoa(j+1)
+			statprefix := prefix + ".StatisticValues.member." + strconv.Itoa(j+1)
 			params[statprefix+".Maximum"] = strconv.FormatFloat(stat.Maximum, 'E', 10, 64)
 			params[statprefix+".Minimum"] = strconv.FormatFloat(stat.Minimum, 'E', 10, 64)
 			params[statprefix+".SampleCount"] = strconv.FormatFloat(stat.SampleCount, 'E', 10, 64)


### PR DESCRIPTION
There was a dot missing which resulted in this error message when
trying to put custom metrics:

Type: Sender, Code: MalformedInput, Message:
Key MetricData.member.1Dimensions.member.1.Name must be all
numbers if it starts with an integer

Note `1Dimensions` part.
