### PR TITLE
DynamoDB query uses auth security token if available

### DIFF
--- a/dynamodb/dynamodb.go
+++ b/dynamodb/dynamodb.go
@@ -83,6 +83,11 @@ func (s *Server) queryServer(target string, query *Query) ([]byte, error) {
 	hreq.Header.Set("X-Amz-Date", time.Now().UTC().Format(aws.ISO8601BasicFormat))
 	hreq.Header.Set("X-Amz-Target", target)
 
+	token := s.Auth.Token()
+	if token != "" {
+		hreq.Header.Set("X-Amz-Security-Token", token)
+	}
+
 	signer := aws.NewV4Signer(s.Auth, "dynamodb", s.Region)
 	signer.Sign(hreq)
 


### PR DESCRIPTION
An addendum to the work @alimoeeny did for issue #24. If the security-token is present when running a dynamodb query, use it.
