### PR TITLE
Add SecurityToken to the request so that usage from IAM roles works.

### DIFF
--- a/exp/sns/sign.go
+++ b/exp/sns/sign.go
@@ -50,6 +50,9 @@ func sign(auth aws.Auth, method, path string, params url.Values, headers http.He
 
 func sign(auth aws.Auth, method, path string, params map[string]string, host string) {
 	params["AWSAccessKeyId"] = auth.AccessKey
+	if auth.Token() != "" {
+		params["SecurityToken"] = auth.Token()
+	}
 	params["SignatureVersion"] = "2"
 	params["SignatureMethod"] = "HmacSHA256"
 


### PR DESCRIPTION
I'm not sure why there is a sign method commented out (which does have this snippet implemented), but this parameter is necessary to use SNS from an IAM role.
