### PR TITLE
Enable IAM role access for SQS

### DIFF
--- a/sqs/sign.go
+++ b/sqs/sign.go
@@ -13,6 +13,9 @@ var b64 = base64.StdEncoding
 
 func sign(auth aws.Auth, method, path string, params map[string]string, host string) {
 	params["AWSAccessKeyId"] = auth.AccessKey
+	if auth.Token() != "" {
+		params["SecurityToken"] = auth.Token()
+	}
 	params["SignatureVersion"] = "2"
 	params["SignatureMethod"] = "HmacSHA256"
 


### PR DESCRIPTION
I'm not sure which services need this and which don't - S3 worked without specifying SecurityToken, but SQS seems to need it.
