### PR TITLE
dynamodb: Add Dynamodb conditional put delete

### DIFF
--- a/dynamodb/attribute.go
+++ b/dynamodb/attribute.go
@@ -148,6 +148,15 @@ func (a *Attribute) SetType() bool {
 	return false
 }
 
+func (a *Attribute) SetExists(exists bool) *Attribute {
+	if exists {
+		a.Exists = "true"
+	} else {
+		a.Exists = "false"
+	}
+	return a
+}
+
 func (k *PrimaryKey) HasRange() bool {
 	return k.RangeAttribute != nil
 }

--- a/dynamodb/item.go
+++ b/dynamodb/item.go
@@ -166,6 +166,10 @@ func (t *Table) PutItem(hashKey string, rangeKey string, attributes []Attribute)
 	return t.putItem(hashKey, rangeKey, attributes, nil)
 }
 
+func (t *Table) ConditionalPutItem(hashKey, rangeKey string, attributes, expected []Attribute) (bool, error) {
+	return t.putItem(hashKey, rangeKey, attributes, expected)
+}
+
 func (t *Table) putItem(hashKey, rangeKey string, attributes, expected []Attribute) (bool, error) {
 	if len(attributes) == 0 {
 		return false, errors.New("At least one attribute is required.")
@@ -219,6 +223,10 @@ func (t *Table) deleteItem(key *Key, expected []Attribute) (bool, error) {
 
 func (t *Table) DeleteItem(key *Key) (bool, error) {
 	return t.deleteItem(key, nil)
+}
+
+func (t *Table) ConditionalDeleteItem(key *Key, expected []Attribute) (bool, error) {
+	return t.deleteItem(key, expected)
 }
 
 func (t *Table) AddAttributes(key *Key, attributes []Attribute) (bool, error) {

--- a/dynamodb/item_test.go
+++ b/dynamodb/item_test.go
@@ -69,6 +69,87 @@ var item_without_range_suite = &ItemSuite{
 var _ = gocheck.Suite(item_suite)
 var _ = gocheck.Suite(item_without_range_suite)
 
+func (s *ItemSuite) TestConditionalPutDeleteItem(c *gocheck.C) {
+	if s.WithRange {
+		// No rangekey test required
+		return
+	}
+
+	attrs := []dynamodb.Attribute{
+		*dynamodb.NewStringAttribute("Attr1", "Attr1Val"),
+	}
+
+	// Put
+	if ok, err := s.table.PutItem("NewHashKeyVal", "", attrs); !ok {
+		c.Fatal(err)
+	}
+
+	{
+		// Put with condition failed
+		expected := []dynamodb.Attribute{
+			*dynamodb.NewStringAttribute("Attr1", "expectedAttr1Val").SetExists(true),
+		}
+		if ok, err := s.table.ConditionalPutItem("NewHashKeyVal", "", attrs, expected); ok {
+			c.Errorf("Expect condition does not meet.")
+		} else {
+			c.Check(err.Error(), gocheck.Matches, "ConditionalCheckFailedException.*")
+		}
+	}
+
+	pk := &dynamodb.Key{HashKey: "NewHashKeyVal"}
+
+	{
+		// Put with condition met
+		expected := []dynamodb.Attribute{
+			*dynamodb.NewStringAttribute("Attr1", "Attr1Val").SetExists(true),
+		}
+		newattrs := []dynamodb.Attribute{
+			*dynamodb.NewStringAttribute("Attr1", "Attr2Val"),
+		}
+		if ok, err := s.table.ConditionalPutItem("NewHashKeyVal", "", newattrs, expected); !ok {
+			c.Errorf("Expect condition met. %s", err)
+		}
+
+		// Get to verify Put operation that condition are met
+		item, err := s.table.GetItem(pk)
+		if err != nil {
+			c.Fatal(err)
+		}
+
+		if val, ok := item["Attr1"]; ok {
+			c.Check(val, gocheck.DeepEquals, dynamodb.NewStringAttribute("Attr1", "Attr2Val"))
+		} else {
+			c.Error("Expect Attr1 attribute to be updated")
+		}
+	}
+
+	{
+		// Delete with condition failed
+		expected := []dynamodb.Attribute{
+			*dynamodb.NewStringAttribute("Attr1", "expectedAttr1Val").SetExists(true),
+		}
+		if ok, err := s.table.ConditionalDeleteItem(pk, expected); ok {
+			c.Errorf("Expect condition does not meet.")
+		} else {
+			c.Check(err.Error(), gocheck.Matches, "ConditionalCheckFailedException.*")
+		}
+	}
+
+	{
+		// Delete with condition met
+		expected := []dynamodb.Attribute{
+			*dynamodb.NewStringAttribute("Attr1", "Attr2Val").SetExists(true),
+		}
+		if ok, _ := s.table.ConditionalDeleteItem(pk, expected); !ok {
+			c.Errorf("Expect condition met.")
+		}
+
+		// Get to verify Delete operation
+		_, err := s.table.GetItem(pk)
+		c.Check(err.Error(), gocheck.Matches, "Item not found")
+	}
+}
+
 func (s *ItemSuite) TestPutGetDeleteItem(c *gocheck.C) {
 	attrs := []dynamodb.Attribute{
 		*dynamodb.NewStringAttribute("Attr1", "Attr1Val"),

--- a/dynamodb/query_builder_test.go
+++ b/dynamodb/query_builder_test.go
@@ -147,6 +147,48 @@ func (s *QueryBuilderSuite) TestAddWriteRequestItems(c *gocheck.C) {
 	c.Check(queryJson, gocheck.DeepEquals, expectedJson)
 }
 
+func (s *QueryBuilderSuite) TestAddExpectedQuery(c *gocheck.C) {
+	primary := dynamodb.NewStringAttribute("domain", "")
+	key := dynamodb.PrimaryKey{primary, nil}
+	table := s.server.NewTable("sites", key)
+
+	q := dynamodb.NewQuery(table)
+	q.AddKey(table, &dynamodb.Key{HashKey: "test"})
+
+	expected := []dynamodb.Attribute{
+		*dynamodb.NewStringAttribute("domain", "expectedTest").SetExists(true),
+	}
+	q.AddExpected(expected)
+
+	queryJson, err := simplejson.NewJson([]byte(q.String()))
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	expectedJson, err := simplejson.NewJson([]byte(`
+	{
+		"Expected": {
+			"domain": {
+				"Exists": "true",
+				"Value": {
+					"S": "expectedTest"
+				}
+			}
+		},
+		"Key": {
+			"domain": {
+				"S": "test"
+			}
+		},
+		"TableName": "sites"
+	}
+	`))
+	if err != nil {
+		c.Fatal(err)
+	}
+	c.Check(queryJson, gocheck.DeepEquals, expectedJson)
+}
+
 func (s *QueryBuilderSuite) TestGetItemQuery(c *gocheck.C) {
 	primary := dynamodb.NewStringAttribute("domain", "")
 	key := dynamodb.PrimaryKey{primary, nil}


### PR DESCRIPTION
#76 I also need conditional {Put,Delete}Item. This PR adds Conditional{Put,Delete}Item methods to dynamodb.Table.

See `item_test.go` for usage.
