### PR TITLE
sqs: Makes sure http/client reuse connections between requests

### DIFF
--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -14,6 +14,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/crowdmob/goamz/aws"
+	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -440,6 +442,8 @@ func (s *SQS) query(queueUrl string, params map[string]string, resp interface{})
 		return buildError(r)
 	}
 	err = xml.NewDecoder(r.Body).Decode(resp)
+	io.Copy(ioutil.Discard, r.Body)
+
 	return err
 }
 


### PR DESCRIPTION
When using the SQS client with a large number of goroutines the local ports available are quickly exhausted because the connections are not being reused. The symptom is a large number of connections in TIME_WAIT state and the error "cannot assign requested address". This code makes sure that all content was read before closing the connection so the http/client can reuse it instead of creating a new one.
