### PR TITLE
dynamodb: Remove value if Exists set to false in Expected block

### DIFF
--- a/dynamodb/item_test.go
+++ b/dynamodb/item_test.go
@@ -89,6 +89,7 @@ func (s *ItemSuite) TestConditionalPutUpdateDeleteItem(c *gocheck.C) {
 		// Put with condition failed
 		expected := []dynamodb.Attribute{
 			*dynamodb.NewStringAttribute("Attr1", "expectedAttr1Val").SetExists(true),
+			*dynamodb.NewStringAttribute("AttrNotExists", "").SetExists(false),
 		}
 		if ok, err := s.table.ConditionalPutItem("NewHashKeyVal", "", attrs, expected); ok {
 			c.Errorf("Expect condition does not meet.")

--- a/dynamodb/query_builder.go
+++ b/dynamodb/query_builder.go
@@ -195,8 +195,10 @@ func (q *Query) AddExpected(attributes []Attribute) {
 		if a.Exists != "" {
 			value["Exists"] = a.Exists
 		}
-		//UGH!!  (I miss the query operator)
-		value["Value"] = msi{a.Type: map[bool]interface{}{true: a.SetValues, false: a.Value}[a.SetType()]}
+		// If set Exists to false, we must remove Value
+		if value["Exists"] != "false" {
+			value["Value"] = msi{a.Type: map[bool]interface{}{true: a.SetValues, false: a.Value}[a.SetType()]}
+		}
 		expected[a.Name] = value
 	}
 	q.buffer["Expected"] = expected

--- a/dynamodb/query_builder_test.go
+++ b/dynamodb/query_builder_test.go
@@ -157,6 +157,7 @@ func (s *QueryBuilderSuite) TestAddExpectedQuery(c *gocheck.C) {
 
 	expected := []dynamodb.Attribute{
 		*dynamodb.NewStringAttribute("domain", "expectedTest").SetExists(true),
+		*dynamodb.NewStringAttribute("testKey", "").SetExists(false),
 	}
 	q.AddExpected(expected)
 
@@ -173,6 +174,9 @@ func (s *QueryBuilderSuite) TestAddExpectedQuery(c *gocheck.C) {
 				"Value": {
 					"S": "expectedTest"
 				}
+			},
+			"testKey": {
+				"Exists": "false"
 			}
 		},
 		"Key": {


### PR DESCRIPTION
http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExpectedAttributeValue.html says:

> DynamoDB returns a ValidationException if:
> 
> Exists is true but there is no Value to check. (You expect a value to exist, but don't specify what that value is.)
> 
> Exists is false but you also specify a Value. (You cannot expect an attribute to have a value, while also expecting it not to exist.)
