### PR TITLE
add Tags to the Image struct

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -804,6 +804,7 @@ type Image struct {
 	RootDeviceType     string               `xml:"rootDeviceType"`
 	RootDeviceName     string               `xml:"rootDeviceName"`
 	VirtualizationType string               `xml:"virtualizationType"`
+	Tags               []Tag                `xml:"tagSet>item"`
 	Hypervisor         string               `xml:"hypervisor"`
 	BlockDevices       []BlockDeviceMapping `xml:"blockDeviceMapping>item"`
 }

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -441,6 +441,10 @@ func (s *S) TestDescribeImagesExample(c *gocheck.C) {
 	c.Assert(i0.VirtualizationType, gocheck.Equals, "paravirtual")
 	c.Assert(i0.Hypervisor, gocheck.Equals, "xen")
 
+	c.Assert(i0.Tags, gocheck.HasLen, 1)
+	c.Assert(i0.Tags[0].Key, gocheck.Equals, "Purpose")
+	c.Assert(i0.Tags[0].Value, gocheck.Equals, "EXAMPLE")
+
 	c.Assert(i0.BlockDevices, gocheck.HasLen, 1)
 	c.Assert(i0.BlockDevices[0].DeviceName, gocheck.Equals, "/dev/sda1")
 	c.Assert(i0.BlockDevices[0].SnapshotId, gocheck.Equals, "snap-787e9403")

--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -446,6 +446,12 @@ var DescribeImagesExample = `
                 </item>
             </blockDeviceMapping>
             <virtualizationType>paravirtual</virtualizationType>
+            <tagSet>
+                <item>
+                    <key>Purpose</key>
+                    <value>EXAMPLE</value>
+                </item>
+            </tagSet>
             <hypervisor>xen</hypervisor>
         </item>
     </imagesSet>


### PR DESCRIPTION
Images can have tags. The [URL](https://github.com/bmatsuo/goamz/blob/4b22fe0dd9b5c55761ef08cbcff0be6503e27267/ec2/responses_test.go#L413) accompanying DescribeImagesExample confirms this.
