### PR TITLE
Don't use blinding when signing the policy

### DIFF
--- a/cloudfront/cloudfront.go
+++ b/cloudfront/cloudfront.go
@@ -2,7 +2,6 @@ package cloudfront
 
 import (
 	"crypto"
-	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
 	"encoding/base64"
@@ -72,7 +71,7 @@ func (cf *CloudFront) generateSignature(policy []byte) (string, error) {
 
 	hashed := hash.Sum(nil)
 
-	signed, err := rsa.SignPKCS1v15(rand.Reader, cf.key, crypto.SHA1, hashed)
+	signed, err := rsa.SignPKCS1v15(nil, cf.key, crypto.SHA1, hashed)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Blinding is used to prevent side channel attacks but this is hardly an issue when signing URLs. Since SignPKCS1v15() is basically RSA decrypt, the random reader can be nil to prevent blinding.

This speeds up the signature generation by about one third.
