### PR TITLE
Add MetricName to parameters for ListMetrics if it is set

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -266,6 +266,9 @@ func (c *CloudWatch) ListMetrics(req *ListMetricsRequest) (result *ListMetricsRe
 	if req.Namespace != "" {
 		params["Namespace"] = req.Namespace
 	}
+	if req.MetricName != "" {
+		params["MetricName"] = req.MetricName
+	}
 	if len(req.Dimensions) > 0 {
 		for i, d := range req.Dimensions {
 			prefix := "Dimensions.member." + strconv.Itoa(i+1)


### PR DESCRIPTION
I was trying to use cloudwatch.ListMetrics and realized it wasn't honoring MetricName if it was set.  This change adds it to the params if it isn't the empty string.
