### PR TITLE
ec2: Correctly refresh IAM credentials.

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -128,6 +128,10 @@ func (ec2 *EC2) query(params map[string]string, resp interface{}) error {
 	if endpoint.Path == "" {
 		endpoint.Path = "/"
 	}
+	if ec2.Auth.Token() != "" {
+		params["SecurityToken"] = ec2.Auth.Token()
+	}
+
 	sign(ec2.Auth, "GET", endpoint.Path, params, endpoint.Host)
 	endpoint.RawQuery = multimap(params).Encode()
 	if debug {

--- a/ec2/sign.go
+++ b/ec2/sign.go
@@ -18,9 +18,6 @@ func sign(auth aws.Auth, method, path string, params map[string]string, host str
 	params["AWSAccessKeyId"] = auth.AccessKey
 	params["SignatureVersion"] = "2"
 	params["SignatureMethod"] = "HmacSHA256"
-	if auth.Token() != "" {
-		params["SecurityToken"] = auth.Token()
-	}
 
 	// AWS specifies that the parameters in a signed request must
 	// be provided in the natural order of the keys. This is distinct


### PR DESCRIPTION
Analogous to the patch to sqs in #111.

The tests don't seem to run on my machine at present, so I haven't run them:

```
go test github.com/nelhage/goamz/ec2
# github.com/nelhage/goamz/ec2_test
ec2/ec2_test.go:824: undefined: ec2.FakeTime
ec2/ec2_test.go:825: undefined: ec2.FakeTime
ec2/sign_test.go:15: undefined: ec2.Sign
ec2/sign_test.go:28: undefined: ec2.Sign
ec2/sign_test.go:46: undefined: ec2.Sign
ec2/sign_test.go:53: undefined: ec2.Sign
ec2/sign_test.go:65: undefined: ec2.Sign
FAIL    github.com/nelhage/goamz/ec2 [build failed]
```
