### PR TITLE
Enable individual message delay for SendMessageBatch

### DIFF
--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -108,6 +108,7 @@ type Message struct {
 	ReceiptHandle    string             `xml:"ReceiptHandle"`
 	Attribute        []Attribute        `xml:"Attribute"`
 	MessageAttribute []MessageAttribute `xml:"MessageAttribute"`
+	DelaySeconds     int
 }
 
 type Attribute struct {
@@ -370,6 +371,10 @@ func (q *Queue) SendMessageBatch(msgList []Message) (resp *SendMessageBatchRespo
 		count := idx + 1
 		params[fmt.Sprintf("SendMessageBatchRequestEntry.%d.Id", count)] = fmt.Sprintf("msg-%d", count)
 		params[fmt.Sprintf("SendMessageBatchRequestEntry.%d.MessageBody", count)] = msg.Body
+
+		if msg.DelaySeconds > 0 {
+			params[fmt.Sprintf("SendMessageBatchRequestEntry.%d.DelaySeconds", count)] = strconv.Itoa(msg.DelaySeconds)
+		}
 	}
 
 	err = q.SQS.query(q.Url, params, resp)


### PR DESCRIPTION
Add DelaySeconds to the Message struct.
Use Message.DelaySeconds in SendMessageBatch to set individual message delay in the batch.
