### PR TITLE
Fix File I/O Leak

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -253,6 +253,9 @@ func (b *Bucket) Exists(path string) (exists bool, err error) {
 		if resp.StatusCode/100 == 2 {
 			exists = true
 		}
+		if resp.Body != nil {
+			resp.Body.Close()
+		}
 		return exists, err
 	}
 	return false, fmt.Errorf("S3 Currently Unreachable")
@@ -777,8 +780,12 @@ func (req *request) url() (*url.URL, error) {
 // body will be unmarshalled on it.
 func (s3 *S3) query(req *request, resp interface{}) error {
 	err := s3.prepare(req)
-	if err == nil {
-		_, err = s3.run(req, resp)
+	if err != nil {
+		return err
+	}
+	r, err := s3.run(req, resp)
+	if r != nil && r.Body != nil {
+		r.Body.Close()
 	}
 	return err
 }


### PR DESCRIPTION
This fixes a bug where the http.Response.Body (which is an io.ReadCloser) is left open. If you call to the run() function, it will only close the http.Response.Body only if the second function parameter 'resp' is not nil. Otherwise its returned and the caller must close it. However, the query() function ignores the returned http.Response.Body by assigning to _, so the io reader is left open. If several requests per second are sent, this can cause io flood warnings like 'too many open files'. 
