### PR TITLE
Remove pointer to Error so that dynamodb.Error impelents error correctly...

### DIFF
--- a/dynamodb/dynamodb.go
+++ b/dynamodb/dynamodb.go
@@ -41,7 +41,7 @@ type Error struct {
 	Message    string // The human-oriented error message
 }
 
-func (e *Error) Error() string {
+func (e Error) Error() string {
 	return e.Code + ": " + e.Message
 }
 


### PR DESCRIPTION
Without this you can't do a type assertion on errors returned from dynamodb methods:

impossible type assertion:
        dynamodb.Error does not implement error (Error method has pointer receiver)
