### PR TITLE
Update SQS Protocol Version to 2012-11-05

### DIFF
--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -273,7 +273,9 @@ func (q *Queue) SendMessageWithAttributes(MessageBody string, MessageAttributes 
 		i++
 	}
 
-	err = q.SQS.query(q.Url, params, resp)
+	if err = q.SQS.query(q.Url, params, resp); err != nil {
+		return resp, err
+	}
 
 	// Assert we have expected Attribute MD5 if we've passed any Message Attributes
 	if len(MessageAttributes) > 0 {


### PR DESCRIPTION
I've bumped the SQS protocol version to `2012-11-05`, which has support for message attributes.  This is required to use message attributes against Amazon SQS servers.  Additionally, we check now for `query` errors prior to checking message attribute MD5.
