### PR TITLE
dynamodb: TestConditionalPutUpdateDeleteItem test fails against AWS

### DIFF
--- a/dynamodb/item_test.go
+++ b/dynamodb/item_test.go
@@ -69,6 +69,38 @@ var item_without_range_suite = &ItemSuite{
 var _ = check.Suite(item_suite)
 var _ = check.Suite(item_without_range_suite)
 
+func (s *ItemSuite) TestConditionalAddAttributesItem(c *check.C) {
+	if s.WithRange {
+		// No rangekey test required
+		return
+	}
+
+	attrs := []dynamodb.Attribute{
+		*dynamodb.NewNumericAttribute("AttrN", "10"),
+	}
+	pk := &dynamodb.Key{HashKey: "NewHashKeyVal"}
+
+	// Put
+	if ok, err := s.table.PutItem("NewHashKeyVal", "", attrs); !ok {
+		c.Fatal(err)
+	}
+
+	{
+		// Put with condition failed
+		expected := []dynamodb.Attribute{
+			*dynamodb.NewNumericAttribute("AttrN", "0").SetExists(true),
+			*dynamodb.NewStringAttribute("AttrNotExists", "").SetExists(false),
+		}
+		// Add attributes with condition failed
+		if ok, err := s.table.ConditionalAddAttributes(pk, attrs, expected); ok {
+			c.Errorf("Expect condition does not meet.")
+		} else {
+			c.Check(err.Error(), check.Matches, "ConditionalCheckFailedException.*")
+		}
+
+	}
+}
+
 func (s *ItemSuite) TestConditionalPutUpdateDeleteItem(c *check.C) {
 	if s.WithRange {
 		// No rangekey test required
@@ -92,13 +124,6 @@ func (s *ItemSuite) TestConditionalPutUpdateDeleteItem(c *check.C) {
 			*dynamodb.NewStringAttribute("AttrNotExists", "").SetExists(false),
 		}
 		if ok, err := s.table.ConditionalPutItem("NewHashKeyVal", "", attrs, expected); ok {
-			c.Errorf("Expect condition does not meet.")
-		} else {
-			c.Check(err.Error(), check.Matches, "ConditionalCheckFailedException.*")
-		}
-
-		// Add attributes with condition failed
-		if ok, err := s.table.ConditionalAddAttributes(pk, attrs, expected); ok {
 			c.Errorf("Expect condition does not meet.")
 		} else {
 			c.Check(err.Error(), check.Matches, "ConditionalCheckFailedException.*")


### PR DESCRIPTION
Hello everyone! I tired to run dynamodb tests against real AWS server and got this error:

```
$ go test -v -amazon -local=false
=== RUN Test

----------------------------------------------------------------------
FAIL: item_test.go:72: ItemSuite.TestConditionalPutUpdateDeleteItem

item_test.go:104:
    c.Check(err.Error(), check.Matches, "ConditionalCheckFailedException.*")
... value string = "ValidationException: One or more parameter values were invalid: Action ADD is not supported for the type S"
... regex string = "ConditionalCheckFailedException.*"

OOPS: 23 passed, 1 FAILED
--- FAIL: Test (203.87 seconds)
FAIL
exit status 1
FAIL    github.com/crowdmob/goamz/dynamodb  203.905s
```

This pull request is my naive approach to fix it: tests against local dynamodb fails, but pass on real dynamodb instance.
