### PR TITLE
added TargetArn to Publish

### DIFF
--- a/exp/sns/sns.go
+++ b/exp/sns/sns.go
@@ -183,6 +183,7 @@ type PublishOpt struct {
 	MessageStructure string
 	Subject          string
 	TopicArn         string
+	TargetArn        string
 }
 
 type PublishResp struct {
@@ -211,6 +212,10 @@ func (sns *SNS) Publish(options *PublishOpt) (resp *PublishResp, err error) {
 
 	if options.TopicArn != "" {
 		params["TopicArn"] = options.TopicArn
+	}
+
+	if options.TargetArn != "" {
+		params["TargetArn"] = options.TargetArn
 	}
 
 	err = sns.query(nil, nil, params, resp)


### PR DESCRIPTION
if you only want to send to a single ARN endpoint, than you we gonna need TargetArn as well.
