### PR TITLE
Fix - DeleteSnapshots takes a single snapshot id per request

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -927,7 +927,7 @@ func (ec2 *EC2) CreateSnapshot(volumeId, description string) (resp *CreateSnapsh
 // See http://goo.gl/vwU1y for more details.
 func (ec2 *EC2) DeleteSnapshots(ssid string) (resp *SimpleResp, err error) {
 	params := makeParams("DeleteSnapshot")
-	params["SnapshotId"] = ssId
+	params["SnapshotId.1"] = ssId
 
 	resp = &SimpleResp{}
 	err = ec2.query(params, resp)

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -481,7 +481,7 @@ func (s *S) TestDeleteSnapshotsExample(c *check.C) {
 
 	req := testServer.WaitRequest()
 	c.Assert(req.Form["Action"], check.DeepEquals, []string{"DeleteSnapshot"})
-	c.Assert(req.Form["SnapshotId"], check.DeepEquals, []string{"snap-78a54011"})
+	c.Assert(req.Form["SnapshotId.1"], check.DeepEquals, []string{"snap-78a54011"})
 
 	c.Assert(err, check.IsNil)
 	c.Assert(resp.RequestId, check.Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")


### PR DESCRIPTION
The AWS DeleteSnapshot api only takes a single snapshot id per request.
