### PR TITLE
ADD - add DeregisterImage function and test case

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -981,6 +981,28 @@ func (ec2 *EC2) Snapshots(ids []string, filter *Filter) (resp *SnapshotsResp, er
 	return
 }
 
+// DeregisterImage
+//
+type DeregisterImageResponse struct {
+        RequestId string `xml:"requestId"`
+        Response  bool   `xml:"return"`
+}
+
+// See
+//
+func (ec2 *EC2) DeregisterImage(imageId string) (resp *DeregisterImageResponse, err error) {
+        params := makeParams("DeregisterImage")
+        params["ImageId"] = imageId
+
+        resp = &DeregisterImageResponse{}
+        err = ec2.query(params, resp)
+        if err != nil {
+                return nil, err
+        }
+        return
+}
+
+
 // ---------------------------------------------------------------------------
 // Subnets
 

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -894,4 +894,18 @@ func (s *S) TestDescribeReservedInstancesiExample(c *check.C) {
 
 }
 
+func (s *S) TestDeregisterImage(c *check.C) {
+        testServer.Response(200, nil, DeregisterImageExample)
+
+        resp, err := s.ec2.DeregisterImage("i-1")
+
+        req := testServer.WaitRequest()
+        c.Assert(req.Form["Action"], check.DeepEquals, []string{"DeregisterImage"})
+
+        c.Assert(err, check.IsNil)
+        c.Assert(resp.RequestId, check.Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+        c.Assert(resp.Response, check.Equals, true)
+
+}
+
 

--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -771,3 +771,10 @@ var DescribeReservedInstancesExample = `
    </reservedInstancesSet> 
 </DescribeReservedInstancesResponse>
 `
+var DeregisterImageExample = `
+<DeregisterImageResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+  <return>true</return>
+</DeregisterImageResponse>
+`
+


### PR DESCRIPTION
Add DeregisterImage function to allow removal of old AWS AMI's.
