### PR TITLE
ADD - Add an options struct to allow filtering on images owned by self

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -867,6 +867,11 @@ type Image struct {
 	BlockDevices       []BlockDeviceMapping `xml:"blockDeviceMapping>item"`
 }
 
+type DescribeImagesOptions struct {
+        ExecutableBy string
+        Owner        string
+}
+
 // Images returns details about available images.
 // The ids and filter parameters, if provided, will limit the images returned.
 // For example, to get all the private images associated with this account set
@@ -876,19 +881,26 @@ type Image struct {
 // a very large number of images being returned.
 //
 // See http://goo.gl/SRBhW for more details.
-func (ec2 *EC2) Images(ids []string, filter *Filter) (resp *ImagesResp, err error) {
-	params := makeParams("DescribeImages")
-	for i, id := range ids {
-		params["ImageId."+strconv.Itoa(i+1)] = id
-	}
-	filter.addParams(params)
+func (ec2 *EC2) Images(ids []string, filter *Filter, options *DescribeImagesOptions) (resp *ImagesResp, err error) {
+        params := makeParams("DescribeImages")
+        if options.Owner != "" {
+                params["Owner"] = options.Owner
+        }
+        if options.ExecutableBy != "" {
+                params["Owner"] = options.ExecutableBy
+        }
 
-	resp = &ImagesResp{}
-	err = ec2.query(params, resp)
-	if err != nil {
-		return nil, err
-	}
-	return
+        for i, id := range ids {
+                params["ImageId."+strconv.Itoa(i+1)] = id
+        }
+        filter.addParams(params)
+
+        resp = &ImagesResp{}
+        err = ec2.query(params, resp)
+        if err != nil {
+                return nil, err
+        }
+        return
 }
 
 // Response to a CreateSnapshot request.

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -407,7 +407,12 @@ func (s *S) TestDescribeImagesExample(c *check.C) {
 	filter.Add("key1", "value1")
 	filter.Add("key2", "value2", "value3")
 
-	resp, err := s.ec2.Images([]string{"ami-1", "ami-2"}, filter)
+	options := ec2.DescribeImagesOptions{
+		Owner:        "self",
+		ExecutableBy: "all",
+	}
+
+	resp, err := s.ec2.Images([]string{"ami-1", "ami-2"}, filter, &options)
 
 	req := testServer.WaitRequest()
 	c.Assert(req.Form["Action"], check.DeepEquals, []string{"DescribeImages"})


### PR DESCRIPTION
Note - This changes the Images function signature.

Add an options structure to the Images function as you can not search for AMI images owned by self by adding a filter.
