### PR TITLE
Made UserName optional

### DIFF
--- a/iam/iam.go
+++ b/iam/iam.go
@@ -142,8 +142,10 @@ type GetUserResp struct {
 // See http://goo.gl/ZnzRN for more details.
 func (iam *IAM) GetUser(name string) (*GetUserResp, error) {
 	params := map[string]string{
-		"Action":   "GetUser",
-		"UserName": name,
+		"Action": "GetUser",
+	}
+	if name != "" {
+		params["UserName"] = name
 	}
 	resp := new(GetUserResp)
 	if err := iam.query(params, resp); err != nil {


### PR DESCRIPTION
Following
http://docs.aws.amazon.com/IAM/latest/APIReference/API_GetUser.html
The UserName argument in iam.GetUser() is optional.

In the case where the UserName is omitted, the response returns information about the user making the request. This is incredibly helpful when running code on an instance with an IAM role.

Fixes #192
