### PR TITLE
support customer s3 SSE keys

### DIFF
--- a/s3/sign.go
+++ b/s3/sign.go
@@ -39,34 +39,6 @@ var s3ParamsToSign = map[string]bool{
 	"delete":                       true,
 }
 
-
-type Param struct {
-	K string
-	V string
-}
-type SortableParams []*Param
-func (p SortableParams) Len() int           { return len(p) }
-func (p SortableParams) Less(i, j int) bool { return p[i].K < p[j].K }
-func (p SortableParams) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-func (p SortableParams) Join(kvSep, paramSep string, discardEmpty bool) string {
-	out := ""
-	for _, param := range p {
-		paramStr := ""
-		if discardEmpty && param.V == "" {
-			paramStr += param.K
-		} else {
-			paramStr += param.K+kvSep+param.V
-		}
-		if out == "" {
-			out += paramStr
-		} else {
-			out += paramSep+paramStr
-		}
-	}
-	return out
-}
-
-
 func sign(auth aws.Auth, method, canonicalPath string, params, headers map[string][]string) {
 	var md5, ctype, date, xamz string
 	var xamzDate bool
@@ -116,13 +88,18 @@ func sign(auth aws.Auth, method, canonicalPath string, params, headers map[strin
 	for k, v := range params {
 		if s3ParamsToSign[k] {
 			for _, vi := range v {
-				sarray = append(sarray, &Param{k, vi})
+				if vi == "" {
+					sarray = append(sarray, k)
+				} else {
+					// "When signing you do not encode these values."
+					sarray = append(sarray, k+"="+vi)
+				}
 			}
 		}
 	}
 	if len(sarray) > 0 {
-		sort.Sort(sarray)
-		canonicalPath = canonicalPath + "?" + sarray.Join("=", "&", true)
+		sort.StringSlice(sarray).Sort()
+		canonicalPath = canonicalPath + "?" + strings.Join(sarray, "&")
 	}
 
 	payload := method + "\n" + md5 + "\n" + ctype + "\n" + date + "\n" + xamz + canonicalPath


### PR DESCRIPTION
Adds support for SSE Customer Keys.

I had to modify the signing a bit since there was a bug that caused the sorting to not work properly. Basically Amazon expects the keys to be in sorted order, not the entire key:value string.
