### PR TITLE
Make sqs/Queue.ReceiveMessageWithParameters return MessageAttributes by default

### DIFF
--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -316,6 +316,7 @@ func (q *Queue) ReceiveMessageWithParameters(p map[string]string) (resp *Receive
 	resp = &ReceiveMessageResponse{}
 	params := makeParams("ReceiveMessage")
 	params["AttributeName"] = "All"
+	params["MessageAttributeName"] = "All"
 
 	for k, v := range p {
 		params[k] = v


### PR DESCRIPTION
By default, receiving messages does not return their message attributes, only base attributes. This one-liner fixes that.

I would like to add unit tests to this, but looking at them, it wasn't clear how in the existing tests we ensure that the appropriate parameters are being sent. If someone can point me in the right direction I'd love to add coverage.
