### PR TITLE
Fix s3 signature by sorting x-amz headers by their key

### DIFF
--- a/s3/sign.go
+++ b/s3/sign.go
@@ -42,7 +42,8 @@ var s3ParamsToSign = map[string]bool{
 func sign(auth aws.Auth, method, canonicalPath string, params, headers map[string][]string) {
 	var md5, ctype, date, xamz string
 	var xamzDate bool
-	var sarray []string
+	var keys, sarray []string
+	xheaders := make(map[string]string)
 	for k, v := range headers {
 		k = strings.ToLower(k)
 		switch k {
@@ -56,8 +57,8 @@ func sign(auth aws.Auth, method, canonicalPath string, params, headers map[strin
 			}
 		default:
 			if strings.HasPrefix(k, "x-amz-") {
-				vall := strings.Join(v, ",")
-				sarray = append(sarray, k+":"+vall)
+				keys = append(keys, k)
+				xheaders[k] = strings.Join(v, ",")
 				if k == "x-amz-date" {
 					xamzDate = true
 					date = ""
@@ -65,8 +66,13 @@ func sign(auth aws.Auth, method, canonicalPath string, params, headers map[strin
 			}
 		}
 	}
-	if len(sarray) > 0 {
-		sort.StringSlice(sarray).Sort()
+	if len(keys) > 0 {
+		sort.StringSlice(keys).Sort()
+		for i := range keys {
+			key := keys[i]
+			value := xheaders[key]
+			sarray = append(sarray, key+":"+value)
+		}
 		xamz = strings.Join(sarray, "\n") + "\n"
 	}
 

--- a/s3/sign_test.go
+++ b/s3/sign_test.go
@@ -130,3 +130,19 @@ func (s *S) TestSignExampleUnicodeKeys(c *check.C) {
 	expected := "AWS 0PN5J17HBGZHT7JJ3X82:dxhSBHoI6eVSPcXJqEghlUzZMnY="
 	c.Assert(headers["Authorization"], check.DeepEquals, []string{expected})
 }
+
+func (s *S) TestSignExampleCustomSSE(c *check.C) {
+	method := "GET"
+	path := "/secret/config"
+	params := map[string][]string{}
+	headers := map[string][]string{
+		"Host": {"secret.johnsmith.net:8080"},
+		"Date": {"Tue, 27 Mar 2007 21:06:08 +0000"},
+		"x-amz-server-side-encryption-customer-key":       {"MWJhakVna1dQT1B0SDFMeGtVVnRQRTFGaU1ldFJrU0I="},
+		"x-amz-server-side-encryption-customer-key-MD5":   {"glIqxpqQ4a9aoK/iLttKzQ=="},
+		"x-amz-server-side-encryption-customer-algorithm": {"AES256"},
+	}
+	s3.Sign(testAuth, method, path, params, headers)
+	expected := "AWS 0PN5J17HBGZHT7JJ3X82:Xq6PWmIo0aOWq+LDjCEiCGgbmHE="
+	c.Assert(headers["Authorization"], check.DeepEquals, []string{expected})
+}


### PR DESCRIPTION
This fix getting **The request signature we calculated does not match the signature you provided. Check your key and signing method** error when using server-side encryption headers with s3.

To create the signature for s3, headers need to be sorted by their key. Currently they are sorted with `key:value`. This is not a problem most of the time, except when one header is the root of another one as for custom server side encryption headers `x-amz-server-side-encryption-customer-key` and `x-amz-server-side-encryption-customer-key-md5`.

See https://github.com/aws/aws-sdk-js/blob/master/lib/signers/s3.js#L82 for correct implementation.
