### PR TITLE
Fix S3 Bucket Endpoint URL for us-east

### DIFF
--- a/aws/regions.go
+++ b/aws/regions.go
@@ -23,7 +23,7 @@ var USEast = Region{
 	"us-east-1",
 	"https://ec2.us-east-1.amazonaws.com",
 	"https://s3.amazonaws.com",
-	"",
+	"https://${bucket}.s3.amazonaws.com",
 	false,
 	false,
 	"https://sdb.amazonaws.com",


### PR DESCRIPTION
For me, running any request to a bucket on us-east results in

```
Get : 301 response missing Location header
```

Because AWS returns incorrect 301 responses, which go does not expose.
When hitting the bucket with `curl https://s3.amazonaws.com/<bucket-name>`, S3 responds with the correct endpoint. This patch fixes the endpoint, at least for us-east.
