### PR TITLE
dynamodb: Fix #212 Iterate over sorted keys by action for stable testing

### DIFF
--- a/dynamodb/query_builder.go
+++ b/dynamodb/query_builder.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"encoding/json"
+	"sort"
 )
 
 type msi map[string]interface{}
@@ -83,7 +84,18 @@ func (q *Query) AddWriteRequestItems(tableItems map[*Table]map[string][][]Attrib
 		for table, itemActions := range tableItems {
 			out[table.Name] = func() interface{} {
 				out2 := []interface{}{}
-				for action, items := range itemActions {
+
+				// here breaks an order of array....
+				// For now, we iterate over sorted key by action for stable testing
+				keys := []string{}
+				for k := range itemActions {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+
+				for ki := range keys {
+					action := keys[ki]
+					items := itemActions[action]
 					for _, attributes := range items {
 						Item_or_Key := map[bool]string{true: "Item", false: "Key"}[action == "Put"]
 						out2 = append(out2, msi{action + "Request": msi{Item_or_Key: attributeList(attributes)}})

--- a/dynamodb/query_builder_test.go
+++ b/dynamodb/query_builder_test.go
@@ -96,6 +96,18 @@ func (s *QueryBuilderSuite) TestAddWriteRequestItems(c *check.C) {
     ],
     "FooData": [
       {
+        "DeleteRequest": {
+          "Key": {
+            "TestRangeKeyDel": {
+              "N": "7777777"
+            },
+            "TestHashKeyDel": {
+              "S": "DelKey"
+            }
+          }
+        }
+      },
+      {
         "PutRequest": {
           "Item": {
             "testingstrbatch": {
@@ -121,18 +133,6 @@ func (s *QueryBuilderSuite) TestAddWriteRequestItems(c *check.C) {
             },
             "testing": {
               "N": "444"
-            }
-          }
-        }
-      },
-      {
-        "DeleteRequest": {
-          "Key": {
-            "TestRangeKeyDel": {
-              "N": "7777777"
-            },
-            "TestHashKeyDel": {
-              "S": "DelKey"
             }
           }
         }


### PR DESCRIPTION
See http://golang.org/doc/go1.3#map

I got no error during several minutes with the following:

``` sh
while true; do go test -v || break; done
```

@alimoeeny BTW, I hope travis to be back to this repository...
