### PR TITLE
Allow HTTP 206 responses from S3

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -905,7 +905,7 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 		dump, _ := httputil.DumpResponse(hresp, true)
 		log.Printf("} -> %s\n", dump)
 	}
-	if hresp.StatusCode != 200 && hresp.StatusCode != 204 {
+	if hresp.StatusCode != 200 && hresp.StatusCode != 204 && hresp.StatusCode != 206 {
 		return nil, buildError(hresp)
 	}
 	if resp != nil {


### PR DESCRIPTION
S3 returns '206 Partial Content' when passed a Range header - currently
the code mistakenly treats that as an error.
