### PR TITLE
S3 friendly proxy

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -877,7 +877,7 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 		hreq.Body = ioutil.NopCloser(req.payload)
 	}
 
-    c := http.Client{
+	c := http.Client{
 		Transport: &http.Transport{
 			Dial: func(netw, addr string) (c net.Conn, err error) {
 				deadline := time.Now().Add(s3.ReadTimeout)
@@ -894,7 +894,7 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 				}
 				return
 			},
-            Proxy: http.ProxyFromEnvironment,
+			Proxy: http.ProxyFromEnvironment,
 		},
 	}
 


### PR DESCRIPTION
At the moment, s3 does not use proxy defined in the environment i.e. using HTTP_PROXY. This adds `Proxy: http.ProxyFromEnvironment` to the Transport so that it will use the environment variables if they are defined. Without this, it is not possible to access s3 through a proxy. I don't really know how to add a test for that. Let me know if this is ok or if you want me to submit a new PR with the commits squashed.
