### PR TITLE
aws.GetRegion function has been added which accepts a region code and then returns a Region struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.swp
+*.iml
+*.idea

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -276,6 +276,11 @@ func GetMetaData(path string) (contents []byte, err error) {
 	return []byte(body), err
 }
 
+func GetRegion(regionName string) (region Region) {
+	region = Regions[regionName]
+	return
+}
+
 func getInstanceCredentials() (cred credentials, err error) {
 	credentialPath := "iam/security-credentials/"
 


### PR DESCRIPTION
This simple GetRegion function can be useful if the settings are loaded from a settings file or something and the region code is in string format and this serves as a simple utility function that will return the region object from the string
