### PR TITLE
Bucket lifecycle API interface

### DIFF
--- a/aws/export_test.go
+++ b/aws/export_test.go
@@ -13,7 +13,7 @@ func (s *V4Signer) RequestTime(req *http.Request) time.Time {
 }
 
 func (s *V4Signer) CanonicalRequest(req *http.Request) string {
-	return s.canonicalRequest(req)
+	return s.canonicalRequest(req, "")
 }
 
 func (s *V4Signer) StringToSign(t time.Time, creq string) string {

--- a/aws/sign.go
+++ b/aws/sign.go
@@ -118,13 +118,20 @@ type V4Signer struct {
 	auth        Auth
 	serviceName string
 	region      Region
+	// Add the x-amz-content-sha256 header
+	IncludeXAmzContentSha256 bool
 }
 
 /*
 Return a new instance of a V4Signer capable of signing AWS requests.
 */
 func NewV4Signer(auth Auth, serviceName string, region Region) *V4Signer {
-	return &V4Signer{auth: auth, serviceName: serviceName, region: region}
+	return &V4Signer{
+		auth:        auth,
+		serviceName: serviceName,
+		region:      region,
+		IncludeXAmzContentSha256: false,
+	}
 }
 
 /*
@@ -140,9 +147,13 @@ The signed request will include a new "Authorization" header indicating that the
 Any changes to the request after signing the request will invalidate the signature.
 */
 func (s *V4Signer) Sign(req *http.Request) {
-	req.Header.Set("host", req.Host)                  // host header must be included as a signed header
-	t := s.requestTime(req)                           // Get requst time
-	creq := s.canonicalRequest(req)                   // Build canonical request
+	req.Header.Set("host", req.Host) // host header must be included as a signed header
+	payloadHash := s.payloadHash(req)
+	if s.IncludeXAmzContentSha256 {
+		req.Header.Set("x-amz-content-sha256", payloadHash) // x-amz-content-sha256 contains the payload hash
+	}
+	t := s.requestTime(req)                           // Get request time
+	creq := s.canonicalRequest(req, payloadHash)      // Build canonical request
 	sts := s.stringToSign(t, creq)                    // Build string to sign
 	signature := s.signature(t, sts)                  // Calculate the AWS Signature Version 4
 	auth := s.authorization(req.Header, t, signature) // Create Authorization header value
@@ -199,15 +210,20 @@ canonicalRequest method creates the canonical request according to Task 1 of the
       CanonicalHeaders + '\n' +
       SignedHeaders + '\n' +
       HexEncode(Hash(Payload))
+
+payloadHash is optional; use the empty string and it will be calculated from the request
 */
-func (s *V4Signer) canonicalRequest(req *http.Request) string {
+func (s *V4Signer) canonicalRequest(req *http.Request, payloadHash string) string {
+	if payloadHash == "" {
+		payloadHash = s.payloadHash(req)
+	}
 	c := new(bytes.Buffer)
 	fmt.Fprintf(c, "%s\n", req.Method)
 	fmt.Fprintf(c, "%s\n", s.canonicalURI(req.URL))
 	fmt.Fprintf(c, "%s\n", s.canonicalQueryString(req.URL))
 	fmt.Fprintf(c, "%s\n\n", s.canonicalHeaders(req.Header))
 	fmt.Fprintf(c, "%s\n", s.signedHeaders(req.Header))
-	fmt.Fprintf(c, "%s", s.payloadHash(req))
+	fmt.Fprintf(c, "%s", payloadHash)
 	return c.String()
 }
 
@@ -230,7 +246,7 @@ func (s *V4Signer) canonicalQueryString(u *url.URL) string {
 		k = url.QueryEscape(k)
 		for _, v := range vs {
 			if v == "" {
-				a = append(a, k)
+				a = append(a, k+"=")
 			} else {
 				v = url.QueryEscape(v)
 				a = append(a, k+"="+v)

--- a/s3/lifecycle.go
+++ b/s3/lifecycle.go
@@ -1,0 +1,202 @@
+package s3
+
+import (
+	"crypto/md5"
+	"encoding/base64"
+	"encoding/xml"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// Implements an interface for s3 bucket lifecycle configuration
+// See goo.gl/d0bbDf for details.
+
+const (
+	LifecycleRuleStatusEnabled  = "Enabled"
+	LifecycleRuleStatusDisabled = "Disabled"
+	LifecycleRuleDateFormat     = "2006-01-02"
+	StorageClassGlacier         = "GLACIER"
+)
+
+type Expiration struct {
+	Days *uint  `xml:"Days,omitempty"`
+	Date string `xml:"Date,omitempty"`
+}
+
+// Returns Date as a time.Time.
+func (r *Expiration) ParseDate() (time.Time, error) {
+	return time.Parse(LifecycleRuleDateFormat, r.Date)
+}
+
+type Transition struct {
+	Days         *uint  `xml:"Days,omitempty"`
+	Date         string `xml:"Date,omitempty"`
+	StorageClass string `xml:"StorageClass"`
+}
+
+// Returns Date as a time.Time.
+func (r *Transition) ParseDate() (time.Time, error) {
+	return time.Parse(LifecycleRuleDateFormat, r.Date)
+}
+
+type NoncurrentVersionExpiration struct {
+	Days *uint `xml:"NoncurrentDays,omitempty"`
+}
+
+type NoncurrentVersionTransition struct {
+	Days         *uint  `xml:"NoncurrentDays,omitempty"`
+	StorageClass string `xml:"StorageClass"`
+}
+
+type LifecycleRule struct {
+	ID                          string                       `xml:"ID"`
+	Prefix                      string                       `xml:"Prefix"`
+	Status                      string                       `xml:"Status"`
+	NoncurrentVersionTransition *NoncurrentVersionTransition `xml:"NoncurrentVersionTransition,omitempty"`
+	NoncurrentVersionExpiration *NoncurrentVersionExpiration `xml:"NoncurrentVersionExpiration,omitempty"`
+	Transition                  *Transition                  `xml:"Transition,omitempty"`
+	Expiration                  *Expiration                  `xml:"Expiration,omitempty"`
+}
+
+// Create a lifecycle rule with arbitrary identifier id and object name prefix
+// for which the rules should apply.
+func NewLifecycleRule(id, prefix string) *LifecycleRule {
+	rule := &LifecycleRule{
+		ID:     id,
+		Prefix: prefix,
+		Status: LifecycleRuleStatusEnabled,
+	}
+	return rule
+}
+
+// Adds a transition rule in days.  Overwrites any previous transition rule.
+func (r *LifecycleRule) SetTransitionDays(days uint) {
+	r.Transition = &Transition{
+		Days:         &days,
+		StorageClass: StorageClassGlacier,
+	}
+}
+
+// Adds a transition rule as a date.  Overwrites any previous transition rule.
+func (r *LifecycleRule) SetTransitionDate(date time.Time) {
+	r.Transition = &Transition{
+		Date:         date.Format(LifecycleRuleDateFormat),
+		StorageClass: StorageClassGlacier,
+	}
+}
+
+// Adds an expiration rule in days.  Overwrites any previous expiration rule.
+// Days must be > 0.
+func (r *LifecycleRule) SetExpirationDays(days uint) {
+	r.Expiration = &Expiration{
+		Days: &days,
+	}
+}
+
+// Adds an expiration rule as a date.  Overwrites any previous expiration rule.
+func (r *LifecycleRule) SetExpirationDate(date time.Time) {
+	r.Expiration = &Expiration{
+		Date: date.Format(LifecycleRuleDateFormat),
+	}
+}
+
+// Adds a noncurrent version transition rule.  Overwrites any previous
+// noncurrent version transition rule.
+func (r *LifecycleRule) SetNoncurrentVersionTransitionDays(days uint) {
+	r.NoncurrentVersionTransition = &NoncurrentVersionTransition{
+		Days:         &days,
+		StorageClass: StorageClassGlacier,
+	}
+}
+
+// Adds a noncurrent version expiration rule. Days must be > 0.  Overwrites
+// any previous noncurrent version expiration rule.
+func (r *LifecycleRule) SetNoncurrentVersionExpirationDays(days uint) {
+	r.NoncurrentVersionExpiration = &NoncurrentVersionExpiration{
+		Days: &days,
+	}
+}
+
+// Marks the rule as disabled.
+func (r *LifecycleRule) Disable() {
+	r.Status = LifecycleRuleStatusDisabled
+}
+
+// Marks the rule as enabled (default).
+func (r *LifecycleRule) Enable() {
+	r.Status = LifecycleRuleStatusEnabled
+}
+
+type LifecycleConfiguration struct {
+	XMLName xml.Name          `xml:"LifecycleConfiguration"`
+	Rules   *[]*LifecycleRule `xml:"Rule,omitempty"`
+}
+
+// Adds a LifecycleRule to the configuration.
+func (c *LifecycleConfiguration) AddRule(r *LifecycleRule) {
+	var rules []*LifecycleRule
+	if c.Rules != nil {
+		rules = *c.Rules
+	}
+	rules = append(rules, r)
+	c.Rules = &rules
+}
+
+// Sets the bucket's lifecycle configuration.
+func (b *Bucket) PutLifecycleConfiguration(c *LifecycleConfiguration) error {
+	doc, err := xml.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	buf := makeXmlBuffer(doc)
+	digest := md5.New()
+	size, err := digest.Write(buf.Bytes())
+	if err != nil {
+		return err
+	}
+
+	headers := map[string][]string{
+		"Content-Length": {strconv.FormatInt(int64(size), 10)},
+		"Content-MD5":    {base64.StdEncoding.EncodeToString(digest.Sum(nil))},
+	}
+
+	req := &request{
+		path:    "/",
+		method:  "PUT",
+		bucket:  b.Name,
+		headers: headers,
+		payload: buf,
+		params:  url.Values{"lifecycle": {""}},
+	}
+
+	return b.S3.queryV4Sign(req, nil)
+}
+
+// Retrieves the lifecycle configuration for the bucket.  AWS returns an error
+// if no lifecycle found.
+func (b *Bucket) GetLifecycleConfiguration() (*LifecycleConfiguration, error) {
+	req := &request{
+		method: "GET",
+		bucket: b.Name,
+		path:   "/",
+		params: url.Values{"lifecycle": {""}},
+	}
+
+	conf := &LifecycleConfiguration{}
+	err := b.S3.queryV4Sign(req, conf)
+	return conf, err
+}
+
+// Delete the bucket's lifecycle configuration.
+func (b *Bucket) DeleteLifecycleConfiguration() error {
+	req := &request{
+		method: "DELETE",
+		bucket: b.Name,
+		path:   "/",
+		params: url.Values{"lifecycle": {""}},
+	}
+
+	return b.S3.queryV4Sign(req, nil)
+}

--- a/s3/lifecycle_test.go
+++ b/s3/lifecycle_test.go
@@ -1,0 +1,205 @@
+package s3_test
+
+import (
+	"encoding/xml"
+	"github.com/crowdmob/goamz/s3"
+	"gopkg.in/check.v1"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func (s *S) TestLifecycleConfiguration(c *check.C) {
+	date, err := time.Parse(s3.LifecycleRuleDateFormat, "2014-09-10")
+	c.Check(err, check.IsNil)
+
+	conf := &s3.LifecycleConfiguration{}
+
+	rule := s3.NewLifecycleRule("transition-days", "/")
+	rule.SetTransitionDays(7)
+	conf.AddRule(rule)
+
+	rule = s3.NewLifecycleRule("transition-date", "/")
+	rule.SetTransitionDate(date)
+	conf.AddRule(rule)
+
+	rule = s3.NewLifecycleRule("expiration-days", "")
+	rule.SetExpirationDays(1)
+	conf.AddRule(rule)
+
+	rule = s3.NewLifecycleRule("expiration-date", "")
+	rule.SetExpirationDate(date)
+	conf.AddRule(rule)
+
+	rule = s3.NewLifecycleRule("noncurrent-transition", "")
+	rule.SetNoncurrentVersionTransitionDays(11)
+	conf.AddRule(rule)
+
+	rule = s3.NewLifecycleRule("noncurrent-expiration", "")
+	rule.SetNoncurrentVersionExpirationDays(1011)
+
+	// Test Disable() and Enable() toggling
+	c.Check(rule.Status, check.Equals, s3.LifecycleRuleStatusEnabled)
+	rule.Disable()
+	c.Check(rule.Status, check.Equals, s3.LifecycleRuleStatusDisabled)
+	rule.Enable()
+	c.Check(rule.Status, check.Equals, s3.LifecycleRuleStatusEnabled)
+	rule.Disable()
+	c.Check(rule.Status, check.Equals, s3.LifecycleRuleStatusDisabled)
+
+	conf.AddRule(rule)
+
+	doc, err := xml.MarshalIndent(conf, "", "  ")
+	c.Check(err, check.IsNil)
+
+	expectedDoc := `<LifecycleConfiguration>
+  <Rule>
+    <ID>transition-days</ID>
+    <Prefix>/</Prefix>
+    <Status>Enabled</Status>
+    <Transition>
+      <Days>7</Days>
+      <StorageClass>GLACIER</StorageClass>
+    </Transition>
+  </Rule>
+  <Rule>
+    <ID>transition-date</ID>
+    <Prefix>/</Prefix>
+    <Status>Enabled</Status>
+    <Transition>
+      <Date>2014-09-10</Date>
+      <StorageClass>GLACIER</StorageClass>
+    </Transition>
+  </Rule>
+  <Rule>
+    <ID>expiration-days</ID>
+    <Prefix></Prefix>
+    <Status>Enabled</Status>
+    <Expiration>
+      <Days>1</Days>
+    </Expiration>
+  </Rule>
+  <Rule>
+    <ID>expiration-date</ID>
+    <Prefix></Prefix>
+    <Status>Enabled</Status>
+    <Expiration>
+      <Date>2014-09-10</Date>
+    </Expiration>
+  </Rule>
+  <Rule>
+    <ID>noncurrent-transition</ID>
+    <Prefix></Prefix>
+    <Status>Enabled</Status>
+    <NoncurrentVersionTransition>
+      <NoncurrentDays>11</NoncurrentDays>
+      <StorageClass>GLACIER</StorageClass>
+    </NoncurrentVersionTransition>
+  </Rule>
+  <Rule>
+    <ID>noncurrent-expiration</ID>
+    <Prefix></Prefix>
+    <Status>Disabled</Status>
+    <NoncurrentVersionExpiration>
+      <NoncurrentDays>1011</NoncurrentDays>
+    </NoncurrentVersionExpiration>
+  </Rule>
+</LifecycleConfiguration>`
+
+	c.Check(string(doc), check.Equals, expectedDoc)
+
+	// Unmarshalling test
+	conf2 := &s3.LifecycleConfiguration{}
+	err = xml.Unmarshal(doc, conf2)
+	c.Check(err, check.IsNil)
+	s.checkLifecycleConfigurationEqual(c, conf, conf2)
+}
+
+func (s *S) checkLifecycleConfigurationEqual(c *check.C, conf, conf2 *s3.LifecycleConfiguration) {
+	c.Check(len(*conf2.Rules), check.Equals, len(*conf.Rules))
+	for i, rule := range *conf2.Rules {
+		confRules := *conf.Rules
+		c.Check(rule, check.DeepEquals, confRules[i])
+	}
+}
+
+func (s *S) checkLifecycleRequest(c *check.C, req *http.Request) {
+	// ?lifecycle= is the only query param
+	v, ok := req.Form["lifecycle"]
+	c.Assert(ok, check.Equals, true)
+	c.Assert(v, check.HasLen, 1)
+	c.Assert(v[0], check.Equals, "")
+
+	c.Assert(req.Header["X-Amz-Date"], check.HasLen, 1)
+	c.Assert(req.Header["X-Amz-Date"][0], check.Not(check.Equals), "")
+
+	// Lifecycle methods require V4 auth
+	usesV4 := strings.HasPrefix(req.Header["Authorization"][0], "AWS4-HMAC-SHA256")
+	c.Assert(usesV4, check.Equals, true)
+}
+
+func (s *S) TestPutLifecycleConfiguration(c *check.C) {
+	testServer.Response(200, nil, "")
+
+	conf := &s3.LifecycleConfiguration{}
+	rule := s3.NewLifecycleRule("id", "")
+	rule.SetTransitionDays(7)
+	conf.AddRule(rule)
+
+	doc, err := xml.Marshal(conf)
+	c.Check(err, check.IsNil)
+
+	b := s.s3.Bucket("bucket")
+	err = b.PutLifecycleConfiguration(conf)
+	c.Assert(err, check.IsNil)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Method, check.Equals, "PUT")
+	c.Assert(req.URL.Path, check.Equals, "/bucket/")
+	c.Assert(req.Header["Content-Md5"], check.HasLen, 1)
+	c.Assert(req.Header["Content-Md5"][0], check.Not(check.Equals), "")
+	s.checkLifecycleRequest(c, req)
+
+	// Check we sent the correct xml serialization
+	data, err := ioutil.ReadAll(req.Body)
+	req.Body.Close()
+	c.Assert(err, check.IsNil)
+	header := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+	c.Assert(string(data), check.Equals, header+string(doc))
+}
+
+func (s *S) TestGetLifecycleConfiguration(c *check.C) {
+	conf := &s3.LifecycleConfiguration{}
+	rule := s3.NewLifecycleRule("id", "")
+	rule.SetTransitionDays(7)
+	conf.AddRule(rule)
+
+	doc, err := xml.Marshal(conf)
+	c.Check(err, check.IsNil)
+
+	testServer.Response(200, nil, string(doc))
+
+	b := s.s3.Bucket("bucket")
+	conf2, err := b.GetLifecycleConfiguration()
+	c.Check(err, check.IsNil)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Method, check.Equals, "GET")
+	c.Assert(req.URL.Path, check.Equals, "/bucket/")
+	s.checkLifecycleRequest(c, req)
+	s.checkLifecycleConfigurationEqual(c, conf, conf2)
+}
+
+func (s *S) TestDeleteLifecycleConfiguration(c *check.C) {
+	testServer.Response(200, nil, "")
+
+	b := s.s3.Bucket("bucket")
+	err := b.DeleteLifecycleConfiguration()
+	c.Check(err, check.IsNil)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Method, check.Equals, "DELETE")
+	c.Assert(req.URL.Path, check.Equals, "/bucket/")
+	s.checkLifecycleRequest(c, req)
+}


### PR DESCRIPTION
AWS Docs: 
http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html

This implements the bucket lifecycle API interface.  Some refactoring was needed because it requires V4 signatures and the `x-amz-content-sha256` header.
