### PR TITLE
add support for scanning indexes, allow external callers to call generic...

### DIFF
--- a/dynamodb/query.go
+++ b/dynamodb/query.go
@@ -3,27 +3,28 @@ package dynamodb
 import (
 	"errors"
 	"fmt"
+
 	simplejson "github.com/bitly/go-simplejson"
 )
 
 func (t *Table) Query(attributeComparisons []AttributeComparison) ([]map[string]*Attribute, error) {
 	q := NewQuery(t)
 	q.AddKeyConditions(attributeComparisons)
-	return runQuery(q, t)
+	return RunQuery(q, t)
 }
 
 func (t *Table) QueryOnIndex(attributeComparisons []AttributeComparison, indexName string) ([]map[string]*Attribute, error) {
 	q := NewQuery(t)
 	q.AddKeyConditions(attributeComparisons)
 	q.AddIndex(indexName)
-	return runQuery(q, t)
+	return RunQuery(q, t)
 }
 
 func (t *Table) LimitedQuery(attributeComparisons []AttributeComparison, limit int64) ([]map[string]*Attribute, error) {
 	q := NewQuery(t)
 	q.AddKeyConditions(attributeComparisons)
 	q.AddLimit(limit)
-	return runQuery(q, t)
+	return RunQuery(q, t)
 }
 
 func (t *Table) LimitedQueryOnIndex(attributeComparisons []AttributeComparison, indexName string, limit int64) ([]map[string]*Attribute, error) {
@@ -31,7 +32,7 @@ func (t *Table) LimitedQueryOnIndex(attributeComparisons []AttributeComparison, 
 	q.AddKeyConditions(attributeComparisons)
 	q.AddIndex(indexName)
 	q.AddLimit(limit)
-	return runQuery(q, t)
+	return RunQuery(q, t)
 }
 
 func (t *Table) CountQuery(attributeComparisons []AttributeComparison) (int64, error) {
@@ -55,7 +56,7 @@ func (t *Table) CountQuery(attributeComparisons []AttributeComparison) (int64, e
 	return itemCount, nil
 }
 
-func runQuery(q *Query, t *Table) ([]map[string]*Attribute, error) {
+func RunQuery(q *Query, t *Table) ([]map[string]*Attribute, error) {
 	jsonResponse, err := t.Server.queryServer("DynamoDB_20120810.Query", q)
 	if err != nil {
 		return nil, err

--- a/dynamodb/query_builder.go
+++ b/dynamodb/query_builder.go
@@ -167,6 +167,14 @@ func (q *Query) AddIndex(value string) {
 	q.buffer["IndexName"] = value
 }
 
+func (q *Query) AddScanIndexForward(val bool) {
+  if val {
+    q.buffer["ScanIndexForward"] = "true"
+  } else {
+    q.buffer["ScanIndexForward"] = "false"
+  }
+}
+
 /*
    "ScanFilter":{
        "AttributeName1":{"AttributeValueList":[{"S":"AttributeValue"}],"ComparisonOperator":"EQ"}


### PR DESCRIPTION
... queries

I added two things in this commit. Happy to split into multiple commits if you would prefer that.
- Support for scanning an index the opposite direction
- Make RunQuery more accessible so external callers can use QueryBuilder style query creation and still be able to execute the queries.
