### PR TITLE
Remove extra s3 hostname

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -903,7 +903,6 @@ func (s3 *S3) setupHttpRequest(req *request) (*http.Request, error) {
 
 	hreq := http.Request{
 		URL:        u,
-		Host:       "s3.amazonaws.com",
 		Method:     req.method,
 		ProtoMajor: 1,
 		ProtoMinor: 1,


### PR DESCRIPTION
Commit 69802b744811077488714d3d2f7b34985987df98 by @xsleonard  included a change which causes the dreaded response:

```
The bucket you are attempting to access must be addressed using the specified endpoint.
Please send all future requests to this endpoint.
```

The URL provided, s3-region-name.amazonaws.com/bucket-name/etc is already sufficient information. Removing the redundant/incorrect host-name fixes this.
