### PR TITLE
Added support for the DescribeTags action

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -1269,10 +1269,8 @@ func (ec2 *EC2) authOrRevoke(op string, group SecurityGroup, perms []IPPerm) (re
 //
 // See http://goo.gl/bncl3 for more details
 type Tag struct {
-	ResourceId   string `xml:"resourceId"`
-	ResourceType string `xml:"resourceType"`
-	Key          string `xml:"key"`
-	Value        string `xml:"value"`
+	Key   string `xml:"key"`
+	Value string `xml:"value"`
 }
 
 // CreateTags adds or overwrites one or more tags for the specified instance ids.
@@ -1295,12 +1293,23 @@ func (ec2 *EC2) CreateTags(instIds []string, tags []Tag) (resp *SimpleResp, err 
 	return resp, nil
 }
 
+// DescribedTag represents key-value metadata used to classify and organize EC2
+// instances. Also includes the Resource ID and type the tag is attached to
+//
+// See http://goo.gl/hgJjO7 for more details.
+type DescribedTag struct {
+	ResourceId   string `xml:"resourceId"`
+	ResourceType string `xml:"resourceType"`
+	Key          string `xml:"key"`
+	Value        string `xml:"value"`
+}
+
 // Response to a DescribeTags request.
 //
 // See http://goo.gl/hgJjO7 for more details.
 type DescribeTagsResp struct {
-	RequestId string `xml:"requestId"`
-	Tags      []Tag  `xml:"tagSet>item"`
+	RequestId string         `xml:"requestId"`
+	Tags      []DescribedTag `xml:"tagSet>item"`
 }
 
 // DescribeTags returns tags about one or more EC2 Resources. Returned tags can

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -808,6 +808,36 @@ func (s *S) TestCreateTags(c *check.C) {
 	c.Assert(resp.RequestId, check.Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
 }
 
+func (s *S) TestDescribeTags(c *check.C) {
+	testServer.Response(200, nil, DescribeTagsExample)
+
+	filter := ec2.NewFilter()
+	filter.Add("key1", "value1")
+
+	resp, err := s.ec2.DescribeTags(filter)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], check.DeepEquals, []string{"DescribeTags"})
+	c.Assert(req.Form["Filter.1.Name"], check.DeepEquals, []string{"key1"})
+	c.Assert(req.Form["Filter.1.Value.1"], check.DeepEquals, []string{"value1"})
+
+	c.Assert(err, check.IsNil)
+	c.Assert(resp.RequestId, check.Equals, "7a62c49f-347e-4fc4-9331-6e8eEXAMPLE")
+	c.Assert(resp.Tags, check.HasLen, 6)
+
+	r0 := resp.Tags[0]
+	c.Assert(r0.Key, check.Equals, "webserver")
+	c.Assert(r0.Value, check.Equals, "")
+	c.Assert(r0.ResourceId, check.Equals, "ami-1a2b3c4d")
+	c.Assert(r0.ResourceType, check.Equals, "image")
+
+	r1 := resp.Tags[1]
+	c.Assert(r1.Key, check.Equals, "stack")
+	c.Assert(r1.Value, check.Equals, "Production")
+	c.Assert(r1.ResourceId, check.Equals, "ami-1a2b3c4d")
+	c.Assert(r1.ResourceType, check.Equals, "image")
+}
+
 func (s *S) TestStartInstances(c *check.C) {
 	testServer.Response(200, nil, StartInstancesExample)
 

--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -702,6 +702,51 @@ var (
 </CreateTagsResponse>
 `
 
+	// http://goo.gl/hgJjO7
+	DescribeTagsExample = `
+<DescribeTagsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
+   <tagSet>
+      <item>
+         <resourceId>ami-1a2b3c4d</resourceId>
+         <resourceType>image</resourceType>
+         <key>webserver</key>
+         <value/>
+      </item>
+       <item>
+         <resourceId>ami-1a2b3c4d</resourceId>
+         <resourceType>image</resourceType>
+         <key>stack</key>
+         <value>Production</value>
+      </item>
+      <item>
+         <resourceId>i-5f4e3d2a</resourceId>
+         <resourceType>instance</resourceType>
+         <key>webserver</key>
+         <value/>
+      </item>
+       <item>
+         <resourceId>i-5f4e3d2a</resourceId>
+         <resourceType>instance</resourceType>
+         <key>stack</key>
+         <value>Production</value>
+      </item>
+      <item>
+         <resourceId>i-12345678</resourceId>
+         <resourceType>instance</resourceType>
+         <key>database_server</key>
+         <value/>
+      </item>
+       <item>
+         <resourceId>i-12345678</resourceId>
+         <resourceType>instance</resourceType>
+         <key>stack</key>
+         <value>Test</value>
+      </item>
+    </tagSet>
+</DescribeTagsResponse>
+`
+
 	// http://goo.gl/awKeF
 	StartInstancesExample = `
 <StartInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">


### PR DESCRIPTION
Documentation for the action can be found here:

http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeTags.html

I hope it's OK!
