### PR TITLE
Set req.Host for V4 sigs only

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -845,6 +845,9 @@ func (s3 *S3) queryV4Sign(req *request, resp interface{}) error {
 		return err
 	}
 
+	// req.Host must be set for V4 signature calculation
+	hreq.Host = hreq.URL.Host
+
 	signer := aws.NewV4Signer(s3.Auth, "s3", s3.Region)
 	signer.IncludeXAmzContentSha256 = true
 	signer.Sign(hreq)


### PR DESCRIPTION
This one shouldn't break other code since this method is used exclusively by changes introduced in #223

The reason for setting `req.Host` is this line:
https://github.com/crowdmob/goamz/blob/master/aws/sign.go#L150

Maybe it could use `req.URL.Host` if `req.Host == ""` there, but that could affect existing uses of the `V4Signer`.
