### PR TITLE
Add support for SecurityToken (IAM/STS) in V4 request signing

### DIFF
--- a/aws/sign.go
+++ b/aws/sign.go
@@ -158,6 +158,12 @@ func (s *V4Signer) Sign(req *http.Request) {
 	signature := s.signature(t, sts)                  // Calculate the AWS Signature Version 4
 	auth := s.authorization(req.Header, t, signature) // Create Authorization header value
 	req.Header.Set("Authorization", auth)             // Add Authorization header to request
+
+	// Add Security Token header if you have a Security Token (usually via IAM role)
+	if s.auth.Token() != "" {
+		req.Header.Set("X-Amz-Security-Token", s.auth.Token())
+	}
+
 	return
 }
 


### PR DESCRIPTION
This commit adds support for using AWS credentials originating from STS in V4-signed calls, by adding the Security Token to the request headers.  Usually these credentials come from IAM roles.

No new tests are attached, since testing this would require a little bit of refactoring of the way aws/sign_test.go obtains its aws.Auth object (aws.Auth.token is private).  If the maintainers are interested, I can go ahead and submit those changes as well.