### PR TITLE
Workaround V4 Signing problem

### DIFF
--- a/exp/sns/sign.go
+++ b/exp/sns/sign.go
@@ -1,0 +1,72 @@
+package sns
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"github.com/crowdmob/goamz/aws"
+	"sort"
+	"strings"
+)
+
+var b64 = base64.StdEncoding
+
+/*
+func sign(auth aws.Auth, method, path string, params url.Values, headers http.Header) {
+    var host string
+    for k, v := range headers {
+        k = strings.ToLower(k)
+        switch k {
+        case "host":
+            host = v[0]
+        }
+    }
+
+    params["AWSAccessKeyId"] = []string{auth.AccessKey}
+    params["SignatureVersion"] = []string{"2"}
+    params["SignatureMethod"] = []string{"HmacSHA256"}
+    if auth.Token() != "" {
+        params["SecurityToken"] = auth.Token()
+    }
+
+    var sarry []string
+    for k, v := range params {
+        sarry = append(sarry, aws.Encode(k) + "=" + aws.Encode(v[0]))
+    }
+
+    sort.StringSlice(sarry).Sort()
+    joined := strings.Join(sarry, "&")
+
+    payload := strings.Join([]string{method, host, "/", joined}, "\n")
+    hash := hmac.NewSHA256([]byte(auth.SecretKey))
+    hash.Write([]byte(payload))
+    signature := make([]byte, b64.EncodedLen(hash.Size()))
+    b64.Encode(signature, hash.Sum())
+
+    params["Signature"] = []string{"AWS " + string(signature)}
+    println("Payload:", payload)
+    println("Signature:", strings.Join(params["Signature"], "|"))
+}*/
+
+func sign(auth aws.Auth, method, path string, params map[string]string, host string) {
+	params["AWSAccessKeyId"] = auth.AccessKey
+	if auth.Token() != "" {
+		params["SecurityToken"] = auth.Token()
+	}
+	params["SignatureVersion"] = "2"
+	params["SignatureMethod"] = "HmacSHA256"
+
+	var sarray []string
+	for k, v := range params {
+		sarray = append(sarray, aws.Encode(k)+"="+aws.Encode(v))
+	}
+	sort.StringSlice(sarray).Sort()
+	joined := strings.Join(sarray, "&")
+	payload := method + "\n" + host + "\n" + path + "\n" + joined
+	hash := hmac.New(sha256.New, []byte(auth.SecretKey))
+	hash.Write([]byte(payload))
+	signature := make([]byte, b64.EncodedLen(hash.Size()))
+	b64.Encode(signature, hash.Sum(nil))
+
+	params["Signature"] = string(signature)
+}

--- a/exp/sns/sns.go
+++ b/exp/sns/sns.go
@@ -32,13 +32,13 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 )
 
 // The SNS type encapsulates operation with an SNS region.
 type SNS struct {
 	aws.Auth
 	aws.Region
-	Signer  *aws.V4Signer
 	private byte // Reserve the right of using private data.
 }
 
@@ -48,7 +48,7 @@ type Topic struct {
 }
 
 func New(auth aws.Auth, region aws.Region) *SNS {
-	return &SNS{auth, region, aws.NewV4Signer(auth, "sns", region), 0}
+	return &SNS{auth, region, 0}
 }
 
 type Message struct {
@@ -121,7 +121,7 @@ func (sns *SNS) ListTopics(NextToken *string) (resp *ListTopicsResp, err error) 
 	if NextToken != nil {
 		params["NextToken"] = *NextToken
 	}
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -132,7 +132,7 @@ func (sns *SNS) CreateTopic(Name string) (resp *CreateTopicResp, err error) {
 	resp = &CreateTopicResp{}
 	params := makeParams("CreateTopic")
 	params["Name"] = Name
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -143,7 +143,7 @@ func (sns *SNS) DeleteTopic(topic Topic) (resp *DeleteTopicResp, err error) {
 	resp = &DeleteTopicResp{}
 	params := makeParams("DeleteTopic")
 	params["TopicArn"] = topic.TopicArn
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -163,7 +163,7 @@ func (sns *SNS) ListSubscriptions(NextToken *string) (resp *ListSubscriptionsRes
 	if NextToken != nil {
 		params["NextToken"] = *NextToken
 	}
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -174,7 +174,7 @@ func (sns *SNS) GetTopicAttributes(TopicArn string) (resp *GetTopicAttributesRes
 	resp = &GetTopicAttributesResp{}
 	params := makeParams("GetTopicAttributes")
 	params["TopicArn"] = TopicArn
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -218,7 +218,7 @@ func (sns *SNS) Publish(options *PublishOpt) (resp *PublishResp, err error) {
 		params["TargetArn"] = options.TargetArn
 	}
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -241,7 +241,7 @@ func (sns *SNS) SetTopicAttributes(AttributeName, AttributeValue, TopicArn strin
 	params["AttributeValue"] = AttributeValue
 	params["TopicArn"] = TopicArn
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -261,7 +261,7 @@ func (sns *SNS) Subscribe(Endpoint, Protocol, TopicArn string) (resp *SubscribeR
 	params["Protocol"] = Protocol
 	params["TopicArn"] = TopicArn
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -278,7 +278,7 @@ func (sns *SNS) Unsubscribe(SubscriptionArn string) (resp *UnsubscribeResponse, 
 
 	params["SubscriptionArn"] = SubscriptionArn
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -307,7 +307,7 @@ func (sns *SNS) ConfirmSubscription(options *ConfirmSubscriptionOpt) (resp *Conf
 	params["Token"] = options.Token
 	params["TopicArn"] = options.TopicArn
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -335,7 +335,7 @@ func (sns *SNS) AddPermission(permissions []Permission, Label, TopicArn string) 
 	params["Label"] = Label
 	params["TopicArn"] = TopicArn
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -353,7 +353,7 @@ func (sns *SNS) RemovePermission(Label, TopicArn string) (resp *RemovePermission
 	params["Label"] = Label
 	params["TopicArn"] = TopicArn
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -380,7 +380,7 @@ func (sns *SNS) ListSubscriptionByTopic(options *ListSubscriptionByTopicOpt) (re
 
 	params["TopicArn"] = options.TopicArn
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -411,7 +411,7 @@ func (sns *SNS) CreatePlatformApplication(options *PlatformApplicationOpt) (resp
 		params[fmt.Sprintf("Attributes.entry.%s.value", strconv.Itoa(i+1))] = attr.Value
 	}
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 
 	return
 
@@ -444,7 +444,7 @@ func (sns *SNS) CreatePlatformEndpoint(options *PlatformEndpointOpt) (resp *Crea
 		params["CustomUserData"] = options.CustomUserData
 	}
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 
 	return
 }
@@ -462,7 +462,7 @@ func (sns *SNS) DeleteEndpoint(endpointArn string) (resp *DeleteEndpointResponse
 
 	params["EndpointArn"] = endpointArn
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 
 	return
 }
@@ -481,7 +481,7 @@ func (sns *SNS) DeletePlatformApplication(platformApplicationArn string) (resp *
 
 	params["PlatformApplicationArn"] = platformApplicationArn
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 
 	return
 }
@@ -501,7 +501,7 @@ func (sns *SNS) GetEndpointAttributes(endpointArn string) (resp *GetEndpointAttr
 
 	params["EndpointArn"] = endpointArn
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 
 	return
 }
@@ -525,7 +525,7 @@ func (sns *SNS) GetPlatformApplicationAttributes(platformApplicationArn, nextTok
 		params["NextToken"] = nextToken
 	}
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 
 	return
 }
@@ -554,7 +554,7 @@ func (sns *SNS) ListEndpointsByPlatformApplication(platformApplicationArn, nextT
 		params["NextToken"] = nextToken
 	}
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 
 }
@@ -581,7 +581,7 @@ func (sns *SNS) ListPlatformApplications(nextToken string) (resp *ListPlatformAp
 		params["NextToken"] = nextToken
 	}
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -608,7 +608,7 @@ func (sns *SNS) SetEndpointAttributes(options *SetEndpointAttributesOpt) (resp *
 		params[fmt.Sprintf("Attributes.entry.%s.value", strconv.Itoa(i+1))] = attr.Value
 	}
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -635,7 +635,7 @@ func (sns *SNS) SetPlatformApplicationAttributes(options *SetPlatformApplication
 		params[fmt.Sprintf("Attributes.entry.%s.value", strconv.Itoa(i+1))] = attr.Value
 	}
 
-	err = sns.query("GET", params, resp)
+	err = sns.query(nil, nil, params, resp)
 	return
 }
 
@@ -655,30 +655,29 @@ type xmlErrors struct {
 	Errors    []Error `xml:"Errors>Error"`
 }
 
-func (sns *SNS) query(method string, params map[string]string, resp interface{}) error {
+func (sns *SNS) query(topic *Topic, message *Message, params map[string]string, resp interface{}) error {
+	params["Timestamp"] = time.Now().UTC().Format(time.RFC3339)
 	u, err := url.Parse(sns.Region.SNSEndpoint)
 	if err != nil {
 		return err
 	}
+
+	sign(sns.Auth, "GET", "/", params, u.Host)
 	u.RawQuery = multimap(params).Encode()
-
-	req, err := http.NewRequest(method, u.String(), nil)
+	r, err := http.Get(u.String())
 	if err != nil {
 		return err
 	}
+	defer r.Body.Close()
 
-	sns.Signer.Sign(req)
-	client := &http.Client{}
-	res, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
+	//dump, _ := http.DumpResponse(r, true)
+	//println("DUMP:\n", string(dump))
+	//return nil
 
-	if res.StatusCode != 200 {
-		return buildError(res)
+	if r.StatusCode != 200 {
+		return buildError(r)
 	}
-	err = xml.NewDecoder(res.Body).Decode(resp)
+	err = xml.NewDecoder(r.Body).Decode(resp)
 	return err
 }
 

--- a/exp/sns/sns_test.go
+++ b/exp/sns/sns_test.go
@@ -115,7 +115,7 @@ func (s *S) TestGetTopicAttributes(c *check.C) {
 func (s *S) TestPublish(c *check.C) {
 	testServer.Response(200, nil, TestPublishXmlOK)
 
-	pubOpt := &sns.PublishOpt{"foobar", "", "subject", "arn:aws:sns:us-east-1:123456789012:My-Topic", ""}
+	pubOpt := &sns.PublishOpt{"foobar", "", "subject", "arn:aws:sns:us-east-1:123456789012:My-Topic"}
 	resp, err := s.sns.Publish(pubOpt)
 	req := testServer.WaitRequest()
 


### PR DESCRIPTION
403 error occurs if the space is included in the message, etc.

``` go:
        sns_client := sns.New(auth, aws.APNortheast)
        pubOpt := &sns.PublishOpt{
                Message:  "aa      a  hoge",
                Subject:  "SNS_Message",
                TopicArn: "xxxxxxxxxxxxxxxxxxxxxxxxx",
        }
        resp, err := sns_client.Publish(pubOpt)
        log.Printf("resp: %#v\n\n", resp)
        log.Printf("err: %#v\n\n", err)
```

Execution result of the above

```
2014/10/04 05:35:53 resp: &sns.PublishResp{MessageId:"", ResponseMetadata:sns.ResponseMetadata{RequestId:"", BoxUsage:0}}

2014/10/04 05:35:53 err: &sns.Error{StatusCode:403, Code:"", Message:"403 Forbidden", RequestId:"e2fe9215-bf24-508b-9c76-debcb490bc6a"}
```

The cause is believed to be a matter of "Signature Version 4 Signing"

http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html

> The space character is a reserved character and must be encoded as "%20" (and not as "+").

but escape of net / url is
https://code.google.com/p/go/source/browse/src/pkg/net/url/url.go?name=go1.3beta1#198

> ```
>            case c == ' ' && mode == encodeQueryComponent:
>                    t[j] = '+'
> ```

I tried the implementation of replace "%20", 
but the 403 error still occurred. 
About this, 
Because there is a possibility of the problem of AWS side of a combination of sns and V4 signing,
its problem inquiry to amazon is ongoing.

As a workaround
I was back port "V2 signing".
