### PR TITLE
Fixed IGW foobar

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -1659,7 +1659,7 @@ type DescribeInternetGatewaysResp struct {
 
 func (ec2 *EC2) DescribeInternetGateways(InternetGatewayIds []string, filter *Filter) (resp *DescribeInternetGatewaysResp, err error) {
 	params := makeParams("DescribeInternetGateways")
-	addParamsList(params, "DescribeInternetGateways", InternetGatewayIds)
+	addParamsList(params, "InternetGatewayId", InternetGatewayIds)
 	filter.addParams(params)
 	resp = &DescribeInternetGatewaysResp{}
 	if err = ec2.query(params, resp); err != nil {


### PR DESCRIPTION
Typo left would cause errors if passed with an IGW value
