### PR TITLE
Fix issue with Route53 instance credentials

### DIFF
--- a/aws/sign.go
+++ b/aws/sign.go
@@ -108,6 +108,9 @@ func (s *Route53Signer) Sign(req *http.Request) {
 	req.Header.Set("X-Amzn-Authorization", authHeader)
 	req.Header.Set("X-Amz-Date", date)
 	req.Header.Set("Content-Type", "application/xml")
+	if s.auth.Token() != "" {
+		req.Header.Set("X-Amzn-Security-Token", s.auth.Token())
+	}
 }
 
 /*


### PR DESCRIPTION
Without the token, the instance credential mode will fail.
