### PR TITLE
Added CreateVolume to EC2 API

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -1570,6 +1570,64 @@ func (ec2 *EC2) AttachVolume(volId string, InstId string, devName string) (resp 
 	return resp, err
 }
 
+type CreateVolumeOptions struct {
+	Size             string
+	SnapshotId       string
+	AvailabilityZone string
+	VolumeType       string
+	IOPS             int
+	Encrypted        bool
+	KmsKeyId         string
+}
+
+type CreateVolumeResp struct {
+	RequestId        string `xml:"requestId"`
+	VolumeId         string `xml:"volumeId"`
+	Size             string `xml:"size"`
+	SnapshotId       string `xml:"snapshotId"`
+	AvailabilityZone string `xml:"availabilityZone"`
+	Status           string `xml:"status"`
+	CreateTime       string `xml:"createTime"`
+	VolumeType       string `xml:"volumeType"`
+	IOPS             int    `xml:"iops"`
+	Encrypted        bool   `xml:"encrypted"`
+	KmsKeyId         string `xml:"kmsKeyId"`
+}
+
+// CreateVolume creates an Amazon EBS volume that can be attached to an instance in the same Availability Zone.
+//
+// See http://goo.gl/DERo1w for more details.
+func (ec2 *EC2) CreateVolume(options CreateVolumeOptions) (resp *CreateVolumeResp, err error) {
+	params := makeParams("CreateVolume")
+	params["AvailabilityZone"] = options.AvailabilityZone
+
+	if options.Size != "" {
+		params["Size"] = options.Size
+	}
+	if options.SnapshotId != "" {
+		params["SnapshotId"] = options.SnapshotId
+	}
+	if options.SnapshotId != "" {
+		params["VolumeType"] = options.VolumeType
+	}
+	if options.IOPS > 0 {
+		params["Iops"] = strconv.Itoa(options.IOPS)
+	}
+	if options.Encrypted {
+		params["Encrypted"] = "true"
+	}
+	if options.KmsKeyId != "" {
+		params["KmsKeyId"] = options.KmsKeyId
+	}
+
+	resp = &CreateVolumeResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, err
+}
+
 type VpcStruct struct {
 	VpcId           string `xml:"vpcId"`
 	State           string `xml:"state"`

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -1057,6 +1057,30 @@ func (s *S) TestAttachVolume(c *check.C) {
 	c.Assert(resp.RequestId, check.Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
 }
 
+func (s *S) TestCreateVolume(c *check.C) {
+	testServer.Response(200, nil, CreateVolumeExample)
+
+	resp, err := s.ec2.CreateVolume(ec2.CreateVolumeOptions{
+		Size:             "1",
+		AvailabilityZone: "us-east-1a",
+	})
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], check.DeepEquals, []string{"CreateVolume"})
+
+	c.Assert(err, check.IsNil)
+	c.Assert(resp.RequestId, check.Equals, "0c67a4c9-d7ec-45ef-8016-bf666EXAMPLE")
+	c.Assert(resp.Size, check.Equals, "1")
+	c.Assert(resp.VolumeId, check.Equals, "vol-2a21e543")
+	c.Assert(resp.AvailabilityZone, check.Equals, "us-east-1a")
+	c.Assert(resp.SnapshotId, check.Equals, "")
+	c.Assert(resp.Status, check.Equals, "creating")
+	c.Assert(resp.CreateTime, check.Equals, "2009-12-28T05:42:53.000Z")
+	c.Assert(resp.VolumeType, check.Equals, "standard")
+	c.Assert(resp.IOPS, check.Equals, 0)
+	c.Assert(resp.Encrypted, check.Equals, false)
+}
+
 func (s *S) TestDescribeVpcs(c *check.C) {
 	testServer.Response(200, nil, DescribeVpcsExample)
 

--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -1054,6 +1054,21 @@ var (
 </AttachVolumeResponse>
 `
 
+	CreateVolumeExample = `
+<CreateVolumeResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+	<requestId>0c67a4c9-d7ec-45ef-8016-bf666EXAMPLE</requestId>
+	<volumeId>vol-2a21e543</volumeId>
+	<size>1</size>
+	<snapshotId/>
+	<availabilityZone>us-east-1a</availabilityZone>
+	<status>creating</status>
+	<createTime>2009-12-28T05:42:53.000Z</createTime>
+	<volumeType>standard</volumeType>
+	<iops>0</iops>
+	<encrypted>false</encrypted>
+</CreateVolumeResponse>
+`
+
 	DescribeVpcsExample = `
 <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>


### PR DESCRIPTION
Add `CreateVolume` to EC2 API.

Right now you can create a snapshot, you can attach a volume, but you couldn't create a volume from a snapshot. Now you can.

`RunInstances` and `AssociateAddress` accept options as a pointer. I don't see a reason why, so I went with the naked value
