### PR TITLE
Add expression support to DynamoDB

### DIFF
--- a/dynamodb/attribute.go
+++ b/dynamodb/attribute.go
@@ -157,6 +157,10 @@ func (a *Attribute) SetExists(exists bool) *Attribute {
 	return a
 }
 
+func (a Attribute) valueMsi() msi {
+	return msi{a.Type: map[bool]interface{}{true: a.SetValues, false: a.Value}[a.SetType()]}
+}
+
 func (k *PrimaryKey) HasRange() bool {
 	return k.RangeAttribute != nil
 }

--- a/dynamodb/dynamodb_test.go
+++ b/dynamodb/dynamodb_test.go
@@ -138,7 +138,7 @@ func setUpAuth(c *check.C) {
 		dynamodb_auth = aws.Auth{AccessKey: "DUMMY_KEY", SecretKey: "DUMMY_SECRET"}
 	} else {
 		c.Log("Using REAL AMAZON SERVER")
-		dynamodb_region = aws.USEast
+		dynamodb_region = aws.USWest2
 		auth, err := aws.EnvAuth()
 		if err != nil {
 			c.Fatal(err)

--- a/dynamodb/query_builder.go
+++ b/dynamodb/query_builder.go
@@ -2,7 +2,9 @@ package dynamodb
 
 import (
 	"encoding/json"
+	"fmt"
 	"sort"
+	"strings"
 )
 
 type msi map[string]interface{}
@@ -233,46 +235,166 @@ func (q *Query) AddItem(attributes []Attribute) {
 	q.buffer["Item"] = attributeList(attributes)
 }
 
-func (q *Query) AddUpdates(attributes []Attribute, action string) {
-	updates := msi{}
-	for _, a := range attributes {
-		au := msi{
-			"Value": msi{
-				a.Type: map[bool]interface{}{true: a.SetValues, false: a.Value}[a.SetType()],
-			},
-			"Action": action,
-		}
-		// Delete 'Value' from AttributeUpdates if Type is not Set
-		if action == "DELETE" && !a.SetType() {
-			delete(au, "Value")
-		}
-		updates[a.Name] = au
-	}
+// New syntax for conditions, filtering, and projection:
+// http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.html
+// Replaces the legacy conditional parameters:
+// http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.html
+//
+// Note that some DynamoDB actions can take two kinds of expression;
+// for example, UpdateItem can have both a ConditionalExpression and UpdateExpression,
+// while Scan can have both a FilterExpression and ProjectionExpression,
+// so the Add*Expression() functions need to share the ExpressionAttributeNames
+// and ExpressionAttribute values query attributes.
+type Expression struct {
+	Text            string
+	AttributeNames  map[string]string
+	AttributeValues []Attribute
+}
 
-	q.buffer["AttributeUpdates"] = updates
+func (q *Query) addExpressionAttributeNames(e *Expression) {
+	expressionAttributeNames := msi{}
+	if existing, ok := q.buffer["ExpressionAttributeNames"]; ok {
+		for k, v := range existing.(msi) {
+			expressionAttributeNames[k] = v
+		}
+	}
+	for k, v := range e.AttributeNames {
+		expressionAttributeNames[k] = v
+	}
+	if len(expressionAttributeNames) > 0 {
+		q.buffer["ExpressionAttributeNames"] = expressionAttributeNames
+	}
+}
+
+func (q *Query) addExpressionAttributeValues(e *Expression) {
+	expressionAttributeValues := msi{}
+	if existing, ok := q.buffer["ExpressionAttributeValues"]; ok {
+		for k, v := range existing.(msi) {
+			expressionAttributeValues[k] = v
+		}
+	}
+	for k, v := range attributeList(e.AttributeValues) {
+		expressionAttributeValues[k] = v
+	}
+	if len(expressionAttributeValues) > 0 {
+		q.buffer["ExpressionAttributeValues"] = expressionAttributeValues
+	}
+}
+
+func (q *Query) AddConditionExpression(e *Expression) {
+	q.buffer["ConditionExpression"] = e.Text
+	q.addExpressionAttributeNames(e)
+	q.addExpressionAttributeValues(e)
+}
+
+func (q *Query) AddFilterExpression(e *Expression) {
+	q.buffer["FilterExpression"] = e.Text
+	q.addExpressionAttributeNames(e)
+	q.addExpressionAttributeValues(e)
+}
+
+func (q *Query) AddProjectionExpression(e *Expression) {
+	q.buffer["ProjectionExpression"] = e.Text
+	q.addExpressionAttributeNames(e)
+	// projection expressions don't have expression attribute values
+}
+
+func (q *Query) AddUpdateExpression(e *Expression) {
+	q.buffer["UpdateExpression"] = e.Text
+	q.addExpressionAttributeNames(e)
+	q.addExpressionAttributeValues(e)
+}
+
+func (q *Query) AddUpdates(attributes []Attribute, action string) {
+	// You can't mix expressions and older mechanisms,
+	// so this reimplements AttributeUpdates using UpdateExpression.
+	e := &Expression{
+		AttributeNames: map[string]string{},
+	}
+	sections := map[string][]string{
+		"SET":    []string{},
+		"ADD":    []string{},
+		"DELETE": []string{},
+		"REMOVE": []string{},
+	}
+	attrIndex := 0
+	for _, a := range attributes {
+		namePlaceholder := fmt.Sprintf("#Updates%d", attrIndex)
+		valuePlaceholder := fmt.Sprintf(":Updates%d", attrIndex)
+		attrIndex++
+
+		e.AttributeNames[namePlaceholder] = a.Name
+		renamedAttr := a
+		renamedAttr.Name = valuePlaceholder
+
+		section := ""
+		update := ""
+		switch action {
+		case "PUT":
+			section = "SET"
+			update = fmt.Sprintf("%s=%s", namePlaceholder, valuePlaceholder)
+			e.AttributeValues = append(e.AttributeValues, renamedAttr)
+		case "ADD":
+			section = "ADD"
+			update = fmt.Sprintf("%s %s", namePlaceholder, valuePlaceholder)
+			e.AttributeValues = append(e.AttributeValues, renamedAttr)
+		case "DELETE":
+			if a.SetType() {
+				section = "DELETE"
+				update = fmt.Sprintf("%s %s", namePlaceholder, valuePlaceholder)
+				e.AttributeValues = append(e.AttributeValues, renamedAttr)
+			} else {
+				section = "REMOVE"
+				update = namePlaceholder
+			}
+		default:
+			panic("Unsupported action: " + action)
+		}
+		sections[section] = append(sections[section], update)
+	}
+	sectionText := []string{}
+	for section, updates := range sections {
+		if len(updates) > 0 {
+			sectionText = append(sectionText, fmt.Sprintf("%s %s", section, strings.Join(updates, ", ")))
+		}
+	}
+	e.Text = strings.Join(sectionText, " ")
+	q.AddUpdateExpression(e)
 }
 
 func (q *Query) AddExpected(attributes []Attribute) {
-	expected := msi{}
-	for _, a := range attributes {
-		value := msi{}
-		if a.Exists != "" {
-			value["Exists"] = a.Exists
-		}
-		// If set Exists to false, we must remove Value
-		if value["Exists"] != "false" {
-			value["Value"] = msi{a.Type: map[bool]interface{}{true: a.SetValues, false: a.Value}[a.SetType()]}
-		}
-		expected[a.Name] = value
+	// You can't mix expressions and older mechanisms,
+	// so this reimplements Expected using ConditionExpression.
+	e := &Expression{
+		AttributeNames: map[string]string{},
 	}
-	q.buffer["Expected"] = expected
+	terms := []string{}
+	attrIndex := 0
+	for _, a := range attributes {
+		namePlaceholder := fmt.Sprintf("#Expected%d", attrIndex)
+		valuePlaceholder := fmt.Sprintf(":Expected%d", attrIndex)
+		attrIndex++
+		e.AttributeNames[namePlaceholder] = a.Name
+
+		term := ""
+		if a.Exists == "false" {
+			term = fmt.Sprintf("attribute_not_exists (%s)", namePlaceholder)
+		} else {
+			term = fmt.Sprintf("%s = %s", namePlaceholder, valuePlaceholder)
+			renamedAttr := a
+			renamedAttr.Name = valuePlaceholder
+			e.AttributeValues = append(e.AttributeValues, renamedAttr)
+		}
+		terms = append(terms, term)
+	}
+	e.Text = strings.Join(terms, " AND ")
+	q.AddConditionExpression(e)
 }
 
 func attributeList(attributes []Attribute) msi {
 	b := msi{}
 	for _, a := range attributes {
-		//UGH!!  (I miss the query operator)
-		b[a.Name] = msi{a.Type: map[bool]interface{}{true: a.SetValues, false: a.Value}[a.SetType()]}
+		b[a.Name] = a.valueMsi()
 	}
 	return b
 }

--- a/dynamodb/query_builder_test.go
+++ b/dynamodb/query_builder_test.go
@@ -167,15 +167,14 @@ func (s *QueryBuilderSuite) TestAddExpectedQuery(c *check.C) {
 
 	expectedJson, err := simplejson.NewJson([]byte(`
 	{
-		"Expected": {
-			"domain": {
-				"Exists": "true",
-				"Value": {
-					"S": "expectedTest"
-				}
-			},
-			"testKey": {
-				"Exists": "false"
+		"ConditionExpression": "#Expected0 = :Expected0 AND attribute_not_exists (#Expected1)",
+		"ExpressionAttributeNames": {
+			"#Expected0": "domain",
+			"#Expected1": "testKey"
+		},
+		"ExpressionAttributeValues": {
+			":Expected0": {
+				"S":"expectedTest"
 			}
 		},
 		"Key": {
@@ -267,12 +266,13 @@ func (s *QueryBuilderSuite) TestUpdateQuery(c *check.C) {
 	}
 	expectedJson, err := simplejson.NewJson([]byte(`
 {
-	"AttributeUpdates": {
-		"count": {
-			"Action": "ADD",
-			"Value": {
-				"N": "4"
-			}
+	"UpdateExpression":"ADD #Updates0 :Updates0",
+	"ExpressionAttributeNames": {
+		"#Updates0": "count"
+	},
+	"ExpressionAttributeValues": {
+		":Updates0": {
+			"N": "4"
 		}
 	},
 	"Key": {
@@ -310,12 +310,13 @@ func (s *QueryBuilderSuite) TestAddUpdates(c *check.C) {
 	}
 	expectedJson, err := simplejson.NewJson([]byte(`
 {
-	"AttributeUpdates": {
-		"StringSet": {
-			"Action": "ADD",
-			"Value": {
-				"SS": ["str", "str2"]
-			}
+	"UpdateExpression": "ADD #Updates0 :Updates0",
+	"ExpressionAttributeNames": {
+		"#Updates0": "StringSet"
+	},
+	"ExpressionAttributeValues": {
+		":Updates0": {
+			"SS": ["str", "str2"]
 		}
 	},
 	"Key": {


### PR DESCRIPTION
I've added [expression](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.html) support to the DynamoDB client. This allows conditional updates based on criteria other than whether an attribute exists or not, and can be used to implement the equivalent of SQL `UPDATE table SET col=MAX(col, :new_col_value) WHERE hash_key=:hash_key_value`.

Since DynamoDB won't accept expression keys and [older pre-expression keys](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.html) in the same requests, I've also reimplemented the query builder's `AddExpected` and `AddUpdates` using expressions. Existing methods on the public interface haven't changed, but I've added `ConditionExpression*` methods alongside `Conditional*` methods.
