### PR TITLE
Explicitly use path?query for V4 signatures

### DIFF
--- a/aws/sign.go
+++ b/aws/sign.go
@@ -231,15 +231,14 @@ func (s *V4Signer) canonicalRequest(req *http.Request, payloadHash string) strin
 }
 
 func (s *V4Signer) canonicalURI(u *url.URL) string {
-	canonicalPath := u.RequestURI()
-	if u.RawQuery != "" {
-		canonicalPath = canonicalPath[:len(canonicalPath)-len(u.RawQuery)-1]
-	}
+	u = &url.URL{Path: u.Path}
+	canonicalPath := u.String()
 	slash := strings.HasSuffix(canonicalPath, "/")
 	canonicalPath = path.Clean(canonicalPath)
 	if canonicalPath != "/" && slash {
 		canonicalPath += "/"
 	}
+
 	return canonicalPath
 }
 


### PR DESCRIPTION
The setting of `url.Opaque` in https://github.com/crowdmob/goamz/commit/be331c13a28a2c3ba0c216c52a5401388d72d235#diff-7db3cb93944d57b2ffc803281c906018R960 causes `url.RequestURI()` to return a full url e.g. `scheme://host/path?query` rather than `path?query` which is invalid for the V4 signature.  `path?query` must be used.
