### PR TITLE
Improve s3 website configuration

### DIFF
--- a/s3/responses_test.go
+++ b/s3/responses_test.go
@@ -234,3 +234,6 @@ var GetLocationUsWest1 = `
 <?xml version="1.0" encoding="UTF-8"?>
 <LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">us-west-1</LocationConstraint>
 `
+
+var BucketWebsiteConfigurationDump = `<?xml version="1.0" encoding="UTF-8"?>
+<WebsiteConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><RedirectAllRequestsTo><HostName>example.com</HostName></RedirectAllRequestsTo></WebsiteConfiguration>`

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -415,21 +415,37 @@ func makeXmlBuffer(doc []byte) *bytes.Buffer {
 	return buf
 }
 
+type IndexDocument struct {
+	Suffix string `xml:"Suffix"`
+}
+
+type ErrorDocument struct {
+	Key string `xml:"Key"`
+}
+
 type RoutingRule struct {
 	ConditionKeyPrefixEquals     string `xml:"Condition>KeyPrefixEquals"`
 	RedirectReplaceKeyPrefixWith string `xml:"Redirect>ReplaceKeyPrefixWith,omitempty"`
 	RedirectReplaceKeyWith       string `xml:"Redirect>ReplaceKeyWith,omitempty"`
 }
 
-type WebsiteConfiguration struct {
-	XMLName             xml.Name       `xml:"http://s3.amazonaws.com/doc/2006-03-01/ WebsiteConfiguration"`
-	IndexDocumentSuffix string         `xml:"IndexDocument>Suffix"`
-	ErrorDocumentKey    string         `xml:"ErrorDocument>Key"`
-	RoutingRules        *[]RoutingRule `xml:"RoutingRules>RoutingRule,omitempty"`
+type RedirectAllRequestsTo struct {
+	HostName string `xml:"HostName"`
+	Protocol string `xml:"Protocol,omitempty"`
 }
 
-func (b *Bucket) PutBucketWebsite(configuration WebsiteConfiguration) error {
+type WebsiteConfiguration struct {
+	XMLName               xml.Name               `xml:"http://s3.amazonaws.com/doc/2006-03-01/ WebsiteConfiguration"`
+	IndexDocument         *IndexDocument         `xml:"IndexDocument,omitempty"`
+	ErrorDocument         *ErrorDocument         `xml:"ErrorDocument,omitempty"`
+	RoutingRules          *[]RoutingRule         `xml:"RoutingRules>RoutingRule,omitempty"`
+	RedirectAllRequestsTo *RedirectAllRequestsTo `xml:"RedirectAllRequestsTo,omitempty"`
+}
 
+// PutBucketWebsite configures a bucket as a website.
+//
+// See http://goo.gl/TpRlUy for details.
+func (b *Bucket) PutBucketWebsite(configuration WebsiteConfiguration) error {
 	doc, err := xml.Marshal(configuration)
 	if err != nil {
 		return err


### PR DESCRIPTION
These changes allow configuring a bucket as a website but redirect all requests to another host. 
Example: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTwebsite.html#RESTBucketPUTwebsite-example2
