### PR TITLE
Add elasticache support to describe a cache cluster

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -68,6 +68,7 @@ type Region struct {
 	KinesisEndpoint        string
 	STSEndpoint            string
 	CloudFormationEndpoint string
+	ElastiCacheEndpoint    string
 }
 
 var Regions = map[string]Region{

--- a/aws/regions.go
+++ b/aws/regions.go
@@ -19,6 +19,7 @@ var USGovWest = Region{
 	"",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.us-gov-west-1.amazonaws.com",
+	"",
 }
 
 var USEast = Region{
@@ -40,6 +41,7 @@ var USEast = Region{
 	"https://kinesis.us-east-1.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.us-east-1.amazonaws.com",
+	"https://elasticache.us-east-1.amazonaws.com",
 }
 
 var USWest = Region{
@@ -61,6 +63,7 @@ var USWest = Region{
 	"",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.us-west-1.amazonaws.com",
+	"https://elasticache.us-west-1.amazonaws.com",
 }
 
 var USWest2 = Region{
@@ -82,6 +85,7 @@ var USWest2 = Region{
 	"https://kinesis.us-west-2.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.us-west-2.amazonaws.com",
+	"https://elasticache.us-west-2.amazonaws.com",
 }
 
 var EUWest = Region{
@@ -103,6 +107,7 @@ var EUWest = Region{
 	"https://kinesis.eu-west-1.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.eu-west-1.amazonaws.com",
+	"https://elasticache.eu-west-1.amazonaws.com",
 }
 
 var EUCentral = Region{
@@ -124,6 +129,7 @@ var EUCentral = Region{
 	"https://kinesis.eu-central-1.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.eu-central-1.amazonaws.com",
+	"",
 }
 
 var APSoutheast = Region{
@@ -145,6 +151,7 @@ var APSoutheast = Region{
 	"https://kinesis.ap-southeast-1.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.ap-southeast-1.amazonaws.com",
+	"https://elasticache.ap-southeast-1.amazonaws.com",
 }
 
 var APSoutheast2 = Region{
@@ -166,6 +173,7 @@ var APSoutheast2 = Region{
 	"https://kinesis.ap-southeast-2.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.ap-southeast-2.amazonaws.com",
+	"https://elasticache.ap-southeast-2.amazonaws.com",
 }
 
 var APNortheast = Region{
@@ -187,6 +195,7 @@ var APNortheast = Region{
 	"https://kinesis.ap-northeast-1.amazonaws.com",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.ap-northeast-1.amazonaws.com",
+	"https://elasticache.ap-northeast-1.amazonaws.com",
 }
 
 var SAEast = Region{
@@ -208,4 +217,5 @@ var SAEast = Region{
 	"",
 	"https://sts.amazonaws.com",
 	"https://cloudformation.sa-east-1.amazonaws.com",
+	"https://elasticache.sa-east-1.amazonaws.com",
 }

--- a/elasticache/elasticache.go
+++ b/elasticache/elasticache.go
@@ -1,0 +1,144 @@
+package elasticache
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/crowdmob/goamz/aws"
+)
+
+var (
+	ErrCacheClusterNotFound = errors.New("Cache cluster not found")
+)
+
+type ElastiCache struct {
+	aws.Auth
+	aws.Region
+}
+
+// DescribeCacheClustersResult represents the response from a
+// DescribeCacheClusters ElastiCache API call
+type DescribeCacheClustersResult struct {
+	CacheClusters []*CacheCluster `xml:"DescribeCacheClustersResult>CacheClusters"`
+}
+
+// CacheCluster represents a cache cluster
+type CacheCluster struct {
+	CacheClusterId string       `xml:"CacheCluster>CacheClusterId"`
+	CacheNodes     []*CacheNode `xml:"CacheCluster>CacheNodes"`
+}
+
+// CacheNode represents a cache node
+type CacheNode struct {
+	Endpoint *Endpoint `xml:"CacheNode>Endpoint"`
+}
+
+// Endpoint represents a cache node endpoint
+type Endpoint struct {
+	Host string `xml:"Address"`
+	Port int    `xml:"Port"`
+}
+
+// New creates a new ElastiCache instance
+func New(auth aws.Auth, region aws.Region) *ElastiCache {
+	return &ElastiCache{auth, region}
+}
+
+// Describe returns information about a cache cluster
+func (ec *ElastiCache) Describe(cluster string) (*CacheCluster, error) {
+	var resp DescribeCacheClustersResult
+	err := ec.query("Action=DescribeCacheClusters&CacheClusterId="+cluster+"&ShowCacheNodeInfo=true", &resp)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.CacheClusters) == 0 {
+		return nil, ErrCacheClusterNotFound
+	}
+
+	return resp.CacheClusters[0], nil
+}
+
+func (ec *ElastiCache) query(query string, response interface{}) error {
+	url := ec.Region.ElastiCacheEndpoint + "/?" + query
+
+	hreq, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		return err
+	}
+
+	hreq.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	hreq.Header.Set("X-Amz-Date", time.Now().UTC().Format(aws.ISO8601BasicFormat))
+
+	token := ec.Auth.Token()
+	if token != "" {
+		hreq.Header.Set("X-Amz-Security-Token", token)
+	}
+
+	signer := aws.NewV4Signer(ec.Auth, "elasticache", ec.Region)
+	signer.Sign(hreq)
+
+	resp, err := http.DefaultClient.Do(hreq)
+
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return buildError(resp)
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return xml.Unmarshal(b, &response)
+}
+
+/* Copied from elb/elb.go - might not be entirely accurate */
+
+// Error encapsulates an error returned by EC.
+type Error struct {
+	// HTTP status code
+	StatusCode int
+	// AWS error code
+	Code string
+	// The human-oriented error message
+	Message string
+}
+
+func (err *Error) Error() string {
+	if err.Code == "" {
+		return err.Message
+	}
+
+	return fmt.Sprintf("%s (%s)", err.Message, err.Code)
+}
+
+type xmlErrors struct {
+	Errors []Error `xml:"Error"`
+}
+
+func buildError(r *http.Response) error {
+	var (
+		err    Error
+		errors xmlErrors
+	)
+	xml.NewDecoder(r.Body).Decode(&errors)
+	if len(errors.Errors) > 0 {
+		err = errors.Errors[0]
+	}
+	err.StatusCode = r.StatusCode
+	if err.Message == "" {
+		err.Message = r.Status
+	}
+	return &err
+}


### PR DESCRIPTION
Adds support for describing an ElastiCache cluster - currently returns the bare minimum needed to get cache node endpoint addresses and ports, e.g. for reconfiguring a redis client at runtime as ElastiCache endpoints change.

Lacking documentation and proper testing, but confirmed to work with multiple cache clusters/nodes in eu-west region.
