### PR TITLE
Add preliminary implementation of PutPartCopy in multi.go

### DIFF
--- a/s3/multi.go
+++ b/s3/multi.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 // Multi represents an unfinished multipart upload.
@@ -139,13 +140,20 @@ func (b *Bucket) InitMulti(key string, contType string, perm ACL, options Option
 	return &Multi{Bucket: b, Key: key, UploadId: resp.UploadId}, nil
 }
 
-func (m *Multi) PutPartCopy(n int, source string) (*CopyObjectResult, Part, error) {
+func (m *Multi) PutPartCopy(n int, options CopyOptions, source string) (*CopyObjectResult, Part, error) {
 	headers := map[string][]string{
 		"x-amz-copy-source": {url.QueryEscape(source)},
 	}
+	options.addHeaders(headers)
 	params := map[string][]string{
 		"uploadId":   {m.UploadId},
 		"partNumber": {strconv.FormatInt(int64(n), 10)},
+	}
+
+	sourceBucket := m.Bucket.S3.Bucket(strings.TrimRight(strings.SplitAfterN(source, "/", 2)[0], "/"))
+	sourceMeta, err := sourceBucket.Head(strings.SplitAfterN(source, "/", 2)[1], nil)
+	if err != nil {
+		return nil, Part{}, err
 	}
 
 	for attempt := attempts.Start(); attempt.Next(); {
@@ -167,7 +175,7 @@ func (m *Multi) PutPartCopy(n int, source string) (*CopyObjectResult, Part, erro
 		if resp.ETag == "" {
 			return nil, Part{}, errors.New("part upload succeeded with no ETag")
 		}
-		return resp, Part{n, resp.ETag, -1}, nil
+		return resp, Part{n, resp.ETag, sourceMeta.ContentLength}, nil
 	}
 	panic("unreachable")
 }

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -68,6 +68,7 @@ type Options struct {
 	RedirectLocation     string
 	ContentMD5           string
 	ContentDisposition   string
+	Range                string
 	// What else?
 	//// The following become headers so they are []strings rather than strings... I think
 	// x-amz-storage-class []string
@@ -75,6 +76,7 @@ type Options struct {
 
 type CopyOptions struct {
 	Options
+	CopySourceOptions string
 	MetadataDirective string
 	ContentType       string
 }
@@ -380,6 +382,9 @@ func (o Options) addHeaders(headers map[string][]string) {
 		headers["x-amz-server-side-encryption-customer-key"] = []string{o.SSECustomerKey}
 		headers["x-amz-server-side-encryption-customer-key-MD5"] = []string{o.SSECustomerKeyMD5}
 	}
+	if len(o.Range) != 0 {
+		headers["Range"] = []string{o.Range}
+	}
 	if len(o.ContentEncoding) != 0 {
 		headers["Content-Encoding"] = []string{o.ContentEncoding}
 	}
@@ -405,6 +410,9 @@ func (o CopyOptions) addHeaders(headers map[string][]string) {
 	o.Options.addHeaders(headers)
 	if len(o.MetadataDirective) != 0 {
 		headers["x-amz-metadata-directive"] = []string{o.MetadataDirective}
+	}
+	if len(o.CopySourceOptions) != 0 {
+		headers["x-amz-copy-source-range"] = []string{o.CopySourceOptions}
 	}
 	if len(o.ContentType) != 0 {
 		headers["Content-Type"] = []string{o.ContentType}


### PR DESCRIPTION
Hey, this is just the alpha version. There are a few things we need to change, but I don't know how to proceed from a goamz design point of view.

The main thing is that the Part I return from putPartCopy currently always has -1 as its size. The reason is that there is no clean way to get the size of the source (because it might be in a different bucket). One solution is to initialize a bucket object for that other bucket and call a Head on the source to get its content length, but that seems really messy. Alternatively, we can leave it to the person doing the putPartCopy to figure out the size, since they have to anyway (because if it is <5 mb their multipart upload will break anyway and they shouldn't be doing a putPartCopy with that source as is).

The current version is functional, since the s3 Complete api call does not require the size of the part, only the etag and part number.

I will also add a test for this new call, but let's figure out what a clean solution to the above problem is first.
