### PR TITLE
PutMetricDataNamespace MetricData.member.1.Value 0

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -372,6 +372,8 @@ func (c *CloudWatch) PutMetricDataNamespace(metrics []MetricDatum, namespace str
 		}
 		if metric.Value != 0 {
 			params[prefix+".Value"] = strconv.FormatFloat(metric.Value, 'E', 10, 64)
+		} else {
+			params[prefix+".Value"] = "0"
 		}
 		if !metric.Timestamp.IsZero() {
 			params[prefix+".Timestamp"] = metric.Timestamp.UTC().Format(time.RFC3339)


### PR DESCRIPTION
Put metric value 0 is normal case. If not send 0, AWS SNS api return error message:
"Type: Sender, Code: InvalidParameterCombination, Message: At least one of the parameters MetricData.member.1.Value and MetricData.member.1.StatisticValues must be specified."
