### PR TITLE
Fix issue where auth token can become empty

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -208,7 +208,10 @@ func (a *Auth) Token() string {
 		return ""
 	}
 	if time.Since(a.expiration) >= -30*time.Second { //in an ideal world this should be zero assuming the instance is synching it's clock
-		*a, _ = GetAuth("", "", "", time.Time{})
+		auth, err := GetAuth("", "", "", time.Time{})
+		if err == nil {
+			*a = auth
+		}
 	}
 	return a.token
 }


### PR DESCRIPTION
This fixes #334 

If we see a token is near expiry, we call GetAuth to refresh it, and
blindly overwrite our token without checking for error. If an error
is returned by GetAuth, we're left with the zero value Auth object,
which is empty. This means all future service calls will fail, and
since the token is now the empty string, we won't try to call GetAuth
again.

This change makes it so we only store the result of GetAuth if it
returns successfully. If it fails, we will keep using our existing
credentials, but each subsequent call to Token will try again to fetch
new credentials.