### PR TITLE
Prevent double slashes in UploadSignedURL

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -844,7 +844,7 @@ func (b *Bucket) UploadSignedURL(path, method, content_type string, expires time
 		log.Println("ERROR sining url for S3 upload", err)
 		return ""
 	}
-	signedurl.Path += path
+	signedurl.Path = path
 	params := url.Values{}
 	params.Add("AWSAccessKeyId", accessId)
 	params.Add("Expires", strconv.FormatInt(expire_date, 10))


### PR DESCRIPTION
The method `UploadSignedURL` can result in incorrect URLs if the given path has a leading slash. All the other methods for signing URLs can handle leading slashes just fine.

This inconsistent behavior can be annoying at times, and always requires special attention to what path is being passed to this method. I believe this should be handled from within the package itself. 

For example, with the following two lines:
```
data.Bucket.UploadSignedURL(fmt.Sprintf("/programs/%s/stdout.txt", prog.Id.Hex()), "PUT", "text/plain", keep)
data.Bucket.SignedURL(fmt.Sprintf("/programs/%s/stdout.txt", prog.Id.Hex()), keep)
```

The first one signs an URL that looks like "https://arturia.s3.amazonaws.com//programs/54d9cc5c39dae80003000001/stdout.txt" (notice the double slashes), while the second one signs an URL that looks like "https://arturia.s3.amazonaws.com/programs/54d9cc5c39dae80003000001/stdout.txt".. .. .. 