### PR TITLE
Expanded support for map type in DynamoDB

### DIFF
--- a/dynamodb/dynamodb.go
+++ b/dynamodb/dynamodb.go
@@ -76,6 +76,7 @@ func (s *Server) queryServer(target string, query Query) ([]byte, error) {
 	numRetries := 0
 	for {
 		data := strings.NewReader(query.String())
+
 		hreq, err := http.NewRequest("POST", s.Region.DynamoDBEndpoint+"/", data)
 		if err != nil {
 			return nil, err

--- a/dynamodb/item.go
+++ b/dynamodb/item.go
@@ -336,42 +336,46 @@ func (t *Table) DeleteDocument(key *Key) error {
 }
 
 func (t *Table) AddAttributes(key *Key, attributes []Attribute) (bool, error) {
-	return t.modifyAttributes(key, attributes, nil, nil, "ADD")
+	return t.modifyAttributes(key, attributes, nil, nil, nil, "ADD")
 }
 
 func (t *Table) UpdateAttributes(key *Key, attributes []Attribute) (bool, error) {
-	return t.modifyAttributes(key, attributes, nil, nil, "PUT")
+	return t.modifyAttributes(key, attributes, nil, nil, nil, "PUT")
 }
 
 func (t *Table) DeleteAttributes(key *Key, attributes []Attribute) (bool, error) {
-	return t.modifyAttributes(key, attributes, nil, nil, "DELETE")
+	return t.modifyAttributes(key, attributes, nil, nil, nil, "DELETE")
 }
 
 func (t *Table) ConditionalAddAttributes(key *Key, attributes, expected []Attribute) (bool, error) {
-	return t.modifyAttributes(key, attributes, expected, nil, "ADD")
+	return t.modifyAttributes(key, attributes, expected, nil, nil, "ADD")
 }
 
 func (t *Table) ConditionalUpdateAttributes(key *Key, attributes, expected []Attribute) (bool, error) {
-	return t.modifyAttributes(key, attributes, expected, nil, "PUT")
+	return t.modifyAttributes(key, attributes, expected, nil, nil, "PUT")
 }
 
 func (t *Table) ConditionalDeleteAttributes(key *Key, attributes, expected []Attribute) (bool, error) {
-	return t.modifyAttributes(key, attributes, expected, nil, "DELETE")
+	return t.modifyAttributes(key, attributes, expected, nil, nil, "DELETE")
 }
 
 func (t *Table) ConditionExpressionAddAttributes(key *Key, attributes []Attribute, condition *Expression) (bool, error) {
-	return t.modifyAttributes(key, attributes, nil, condition, "ADD")
+	return t.modifyAttributes(key, attributes, nil, condition, nil, "ADD")
 }
 
 func (t *Table) ConditionExpressionUpdateAttributes(key *Key, attributes []Attribute, condition *Expression) (bool, error) {
-	return t.modifyAttributes(key, attributes, nil, condition, "PUT")
+	return t.modifyAttributes(key, attributes, nil, condition, nil, "PUT")
 }
 
 func (t *Table) ConditionExpressionDeleteAttributes(key *Key, attributes []Attribute, condition *Expression) (bool, error) {
-	return t.modifyAttributes(key, attributes, nil, condition, "DELETE")
+	return t.modifyAttributes(key, attributes, nil, condition, nil, "DELETE")
 }
 
-func (t *Table) modifyAttributes(key *Key, attributes, expected []Attribute, condition *Expression, action string) (bool, error) {
+func (t *Table) UpdateExpressionUpdateAttributes(key *Key, condition, update *Expression) (bool, error) {
+	return t.modifyAttributes(key, nil, nil, condition, update, "")
+}
+
+func (t *Table) modifyAttributes(key *Key, attributes, expected []Attribute, condition, update *Expression, action string) (bool, error) {
 
 	if len(attributes) == 0 {
 		return false, errors.New("At least one attribute is required.")
@@ -461,6 +465,13 @@ func parseAttributes(s map[string]interface{}) map[string]*Attribute {
 					Type:      TYPE_BINARY_SET,
 					Name:      key,
 					SetValues: arry,
+				}
+			} else if vals, ok := v[TYPE_MAP].(map[string]interface{}); ok {
+				m := parseAttributes(vals)
+				results[key] = &Attribute{
+					Type:      TYPE_MAP,
+					Name:      key,
+					MapValues: m,
 				}
 			}
 		} else {

--- a/dynamodb/item.go
+++ b/dynamodb/item.go
@@ -377,13 +377,19 @@ func (t *Table) UpdateExpressionUpdateAttributes(key *Key, condition, update *Ex
 
 func (t *Table) modifyAttributes(key *Key, attributes, expected []Attribute, condition, update *Expression, action string) (bool, error) {
 
-	if len(attributes) == 0 {
+	if len(attributes) == 0 && update == nil {
 		return false, errors.New("At least one attribute is required.")
 	}
 
 	q := NewQuery(t)
 	q.AddKey(key)
-	q.AddUpdates(attributes, action)
+
+	if len(attributes) > 0 {
+		q.AddUpdates(attributes, action)
+	}
+	if update != nil {
+		q.AddUpdateExpression(update)
+	}
 
 	if expected != nil {
 		q.AddExpected(expected)

--- a/dynamodb/item_test.go
+++ b/dynamodb/item_test.go
@@ -638,7 +638,7 @@ func (s *ItemSuite) TestUpdateItemWithMap(c *check.C) {
 		rk = "1"
 	}
 	if ok, err := s.table.PutItem("NewHashKeyVal", rk, attrs); !ok {
-		c.Error(err)
+		c.Fatal(err)
 	}
 
 	// Verify the PutItem operation
@@ -653,7 +653,16 @@ func (s *ItemSuite) TestUpdateItemWithMap(c *check.C) {
 		}
 	}
 
-	// Update the map attribute via UpdateItem API w/ UpdateExpression
+	// Update the map attribute via UpdateItem API
+	updateAttr := NewStringAttribute(":3", "SubAttr3Val")
+	update := &Expression{
+		Text: "SET #a.#3 = :3",
+		AttributeNames: map[string]string{
+			"#a": "Attr1",
+			"#3": "SubAttr3",
+		},
+		AttributeValues: []Attribute{*updateAttr},
+	}
 	expected := []Attribute{
 		*NewMapAttribute("Attr1",
 			map[string]*Attribute{
@@ -663,7 +672,7 @@ func (s *ItemSuite) TestUpdateItemWithMap(c *check.C) {
 			},
 		),
 	}
-	if ok, err := s.table.UpdateExpressionUpdateAttributes(pk, nil, nil); !ok {
+	if ok, err := s.table.UpdateExpressionUpdateAttributes(pk, nil, update); !ok {
 		c.Fatal(err)
 	}
 
@@ -678,7 +687,7 @@ func (s *ItemSuite) TestUpdateItemWithMap(c *check.C) {
 		}
 	}
 
-	// Overwrite the map via UpdateItem API w/ AttributeUpdates
+	// Overwrite the map via UpdateItem API
 	newAttrs := []Attribute{
 		*NewMapAttribute("Attr1",
 			map[string]*Attribute{
@@ -687,7 +696,7 @@ func (s *ItemSuite) TestUpdateItemWithMap(c *check.C) {
 		),
 	}
 	if ok, err := s.table.UpdateAttributes(pk, newAttrs); !ok {
-		c.Fatal(err)
+		c.Error(err)
 	}
 
 	// Verify the map attribute has been overwritten

--- a/dynamodb/query_builder.go
+++ b/dynamodb/query_builder.go
@@ -195,6 +195,7 @@ func (q *UntypedQuery) AddQueryFilter(comparisons []AttributeComparison) {
 func (q *UntypedQuery) AddLimit(limit int64) {
 	q.buffer["Limit"] = limit
 }
+
 func (q *UntypedQuery) AddSelect(value string) {
 	q.buffer["Select"] = value
 }


### PR DESCRIPTION
For https://github.com/AdRoll/goamz/issues/308

This PR provides a UpdateExpressionUpdateAttributes method on Table that will allow us to support arbitrary UpdateExpressions to the underlying UpdateItem API endpoint.

The existing UpdateAttributes method on Table could potentially be modified to support a limited subset of UpdateExpressions, but it can't support semantics like "SET #key1.#key2=:val1" that are permitted by the DynamoDB API. Adding a new method rather than extending the existing interface will allow consuming code to avoid the complexity of writing an UpdateExpression unless it's actually needed to express operations on fields of a map (or multiple operations such as a SET and DELETE in the same call). Examples are provided in the associated test code.

Includes:
- extended dynamo Attribute struct to include Map support
- added recursive parsing of Maps in parseAttributes
- follow nested structs during output to map[string]interface{} to allow Query/Scan operations to support maps
- expanded testing of Query/Scan operations so that Map is covered

I've run the full dynamodb package's test suite via `go test -check.vv -amazon -local`