### PR TITLE
StartKey is now used rather than trying to map the result back to a Key.

### DIFF
--- a/dynamodb/attribute.go
+++ b/dynamodb/attribute.go
@@ -39,6 +39,8 @@ type PrimaryKey struct {
 	RangeAttribute *Attribute
 }
 
+type StartKey map[string]interface{}
+
 type Attribute struct {
 	Type      string
 	Name      string

--- a/dynamodb/dynamo_query_builder.go
+++ b/dynamodb/dynamo_query_builder.go
@@ -88,7 +88,7 @@ func (q *DynamoQuery) AddItem(key *Key, item dynamizer.DynamoItem) error {
 	return nil
 }
 
-func (q *DynamoQuery) AddExclusiveStartKey(key *Key) error {
+func (q *DynamoQuery) AddExclusiveStartKey(key StartKey) error {
 	panic("not implemented")
 	return nil
 }

--- a/dynamodb/query.go
+++ b/dynamodb/query.go
@@ -9,7 +9,7 @@ import (
 
 type Query interface {
 	AddKey(key *Key) error
-	AddExclusiveStartKey(key *Key) error
+	AddExclusiveStartKey(key StartKey) error
 	AddExclusiveStartTableName(table string) error
 	SetConsistentRead(c bool) error
 	String() string
@@ -64,7 +64,7 @@ func (t *Table) CountQuery(attributeComparisons []AttributeComparison) (int64, e
 	return itemCount, nil
 }
 
-func (t *Table) QueryTable(q Query) ([]map[string]*Attribute, *Key, error) {
+func (t *Table) QueryTable(q Query) ([]map[string]*Attribute, StartKey, error) {
 	jsonResponse, err := t.Server.queryServer(target("Query"), q)
 	if err != nil {
 		return nil, nil, err
@@ -92,9 +92,9 @@ func (t *Table) QueryTable(q Query) ([]map[string]*Attribute, *Key, error) {
 		results[i] = parseAttributes(item)
 	}
 
-	var lastEvaluatedKey *Key
+	var lastEvaluatedKey StartKey
 	if lastKeyMap := json.Get("LastEvaluatedKey").MustMap(); lastKeyMap != nil {
-		lastEvaluatedKey = parseKey(t, lastKeyMap)
+                lastEvaluatedKey = lastKeyMap
 	}
 
 	return results, lastEvaluatedKey, nil

--- a/dynamodb/query_builder.go
+++ b/dynamodb/query_builder.go
@@ -43,11 +43,11 @@ func (q *UntypedQuery) AddKey(key *Key) error {
 	return nil
 }
 
-func (q *UntypedQuery) AddExclusiveStartKey(key *Key) error {
+func (q *UntypedQuery) AddExclusiveStartKey(key StartKey) error {
 	if q.table == nil {
 		return errors.New("Table is nil")
 	}
-	q.buffer["ExclusiveStartKey"] = keyAttributes(q.table, key)
+	q.buffer["ExclusiveStartKey"] = key
 	return nil
 }
 

--- a/dynamodb/scan.go
+++ b/dynamodb/scan.go
@@ -8,7 +8,7 @@ import (
 	simplejson "github.com/bitly/go-simplejson"
 )
 
-func (t *Table) FetchPartialResults(query Query) ([]map[string]*Attribute, *Key, error) {
+func (t *Table) FetchPartialResults(query Query) ([]map[string]*Attribute, StartKey, error) {
 	jsonResponse, err := t.Server.queryServer(target("Scan"), query)
 	if err != nil {
 		return nil, nil, err
@@ -35,9 +35,9 @@ func (t *Table) FetchPartialResults(query Query) ([]map[string]*Attribute, *Key,
 		results[i] = parseAttributes(item)
 	}
 
-	var lastEvaluatedKey *Key
+	var lastEvaluatedKey StartKey
 	if lastKeyMap := json.Get("LastEvaluatedKey").MustMap(); lastKeyMap != nil {
-		lastEvaluatedKey = parseKey(t, lastKeyMap)
+		lastEvaluatedKey = lastKeyMap
 	}
 
 	return results, lastEvaluatedKey, nil
@@ -64,19 +64,19 @@ func (t *Table) FetchResultCallbackIterator(query Query, cb func(map[string]*Att
 	return nil
 }
 
-func (t *Table) ScanPartial(attributeComparisons []AttributeComparison, exclusiveStartKey *Key) ([]map[string]*Attribute, *Key, error) {
+func (t *Table) ScanPartial(attributeComparisons []AttributeComparison, exclusiveStartKey StartKey) ([]map[string]*Attribute, StartKey, error) {
 	return t.ParallelScanPartialLimit(attributeComparisons, exclusiveStartKey, 0, 0, 0)
 }
 
-func (t *Table) ScanPartialLimit(attributeComparisons []AttributeComparison, exclusiveStartKey *Key, limit int64) ([]map[string]*Attribute, *Key, error) {
+func (t *Table) ScanPartialLimit(attributeComparisons []AttributeComparison, exclusiveStartKey StartKey, limit int64) ([]map[string]*Attribute, StartKey, error) {
 	return t.ParallelScanPartialLimit(attributeComparisons, exclusiveStartKey, 0, 0, limit)
 }
 
-func (t *Table) ParallelScanPartial(attributeComparisons []AttributeComparison, exclusiveStartKey *Key, segment, totalSegments int) ([]map[string]*Attribute, *Key, error) {
+func (t *Table) ParallelScanPartial(attributeComparisons []AttributeComparison, exclusiveStartKey StartKey, segment, totalSegments int) ([]map[string]*Attribute, StartKey, error) {
 	return t.ParallelScanPartialLimit(attributeComparisons, exclusiveStartKey, segment, totalSegments, 0)
 }
 
-func (t *Table) ParallelScanPartialLimit(attributeComparisons []AttributeComparison, exclusiveStartKey *Key, segment, totalSegments int, limit int64) ([]map[string]*Attribute, *Key, error) {
+func (t *Table) ParallelScanPartialLimit(attributeComparisons []AttributeComparison, exclusiveStartKey StartKey, segment, totalSegments int, limit int64) ([]map[string]*Attribute, StartKey, error) {
 	q := NewQuery(t)
 	q.AddScanFilter(attributeComparisons)
 	if exclusiveStartKey != nil {


### PR DESCRIPTION
When Indexes are used for Query or Scan the returned LastEvaluatedKey includes additional fields such as the fields you're querying upon. Based upon documentation passing this value back allows fetching of next set of results.