### PR TITLE
s3test: Fix potential nil dereference on multipart complete

### DIFF
--- a/s3/s3test/server.go
+++ b/s3/s3test/server.go
@@ -811,6 +811,14 @@ func (objr objectResource) post(a *action) interface{} {
 		delete(objr.bucket.multipartUploads, uploadId)
 
 		obj := objr.object
+
+		if obj == nil {
+			obj = &object{
+				name: objr.name,
+				meta: make(http.Header),
+			}
+		}
+
 		obj.data = data.Bytes()
 		obj.checksum = sum.Sum(nil)
 		obj.mtime = time.Now()


### PR DESCRIPTION
Somehow my initial tests missed that case, which is handled for normal PUTs