### PR TITLE
Fix SDB request signing on auth expiry

### DIFF
--- a/exp/sdb/sign.go
+++ b/exp/sdb/sign.go
@@ -27,12 +27,12 @@ func sign(auth aws.Auth, method, path string, params url.Values, headers http.He
 	}
 
 	// set up some defaults used for signing the request
-	params["AWSAccessKeyId"] = []string{auth.AccessKey}
-	params["SignatureVersion"] = []string{"2"}
-	params["SignatureMethod"] = []string{"HmacSHA256"}
 	if auth.Token() != "" {
 		params["SecurityToken"] = []string{auth.Token()}
 	}
+	params["AWSAccessKeyId"] = []string{auth.AccessKey}
+	params["SignatureVersion"] = []string{"2"}
+	params["SignatureMethod"] = []string{"HmacSHA256"}
 
 	// join up all the incoming params
 	var sarray []string


### PR DESCRIPTION
When using temporary IAM credentials, the auth.Token() function will update the auth.AccessKey when the credentials have expired. As such, the call to the auth.Token() function should be before, not after the usage of auth.AccessKey.