### PR TITLE
change AliasTarget into a pointer (restore ability to change non-alias records)

### DIFF
--- a/route53/route53.go
+++ b/route53/route53.go
@@ -76,7 +76,7 @@ type Change struct {
 	Name        string                `xml:"ResourceRecordSet>Name"`
 	Type        string                `xml:"ResourceRecordSet>Type"`
 	TTL         int                   `xml:"ResourceRecordSet>TTL,omitempty"`
-	AliasTarget AliasTarget           `xml:"ResourceRecordSet>AliasTarget,omitempty"`
+	AliasTarget *AliasTarget          `xml:"ResourceRecordSet>AliasTarget,omitempty"`
 	Values      []ResourceRecordValue `xml:"ResourceRecordSet>ResourceRecords,omitempty"`
 }
 


### PR DESCRIPTION
Issue #164 and subsequent commit b3599a4 broke ability to change resource record sets for all non-alias records (which are arguably a more common use case than alias records).
This was due to `omitempty` not working on structs. The simplest way I can think of of fixing this without too much impact to to make AliasTarget into a pointer. A nil pointer is then marshalled and doesn't end up in the resulting XML.

