### PR TITLE
Revise error message for KMS

### DIFF
--- a/kms/kms_test.go
+++ b/kms/kms_test.go
@@ -49,3 +49,11 @@ func (s *S) TestDescribeKey(c *check.C) {
 	c.Assert(desc.KeyMetadata.KeyId, check.Equals, "12345678-1234-1234-1234-123456789012")
 	c.Assert(desc.KeyMetadata.KeyUsage, check.Equals, "ENCRYPT_DECRYPT")
 }
+
+func (s *S) TestErrorCase(c *check.C) {
+	testServer.Response(400, nil, ErrorExample)
+
+	_, err := s.kms.DescribeKey(kms.DescribeKeyInfo{KeyId: "alias/test"})
+
+	c.Assert(err, check.ErrorMatches, "Type: TestException, Code: 400, Message: This is a error test")
+}

--- a/kms/response_test.go
+++ b/kms/response_test.go
@@ -13,3 +13,10 @@ var DescribeKeyExample = `
 	}
 }
 `
+
+var ErrorExample = `
+{
+    "__type": "TestException",
+    "message": "This is a error test"
+}
+`


### PR DESCRIPTION
Because original design only reports simple error, in order to take action on specific error, error message should be more detail