### PR TITLE
s3: Properly check errors when completing multipart commits

### DIFF
--- a/s3/multi_test.go
+++ b/s3/multi_test.go
@@ -343,10 +343,7 @@ func (s *S) TestPutAllResume(c *check.C) {
 
 func (s *S) TestMultiComplete(c *check.C) {
 	testServer.Response(200, nil, InitMultiResultDump)
-	// Note the 200 response. Completing will hold the connection on some
-	// kind of long poll, and may return a late error even after a 200.
-	testServer.Response(200, nil, InternalErrorDump)
-	testServer.Response(200, nil, "")
+	testServer.Response(200, nil, MultiCompleteDump)
 
 	b := s.s3.Bucket("sample")
 
@@ -380,6 +377,24 @@ func (s *S) TestMultiComplete(c *check.C) {
 	c.Assert(payload.Part[0].ETag, check.Equals, `"ETag1"`)
 	c.Assert(payload.Part[1].PartNumber, check.Equals, 2)
 	c.Assert(payload.Part[1].ETag, check.Equals, `"ETag2"`)
+}
+
+func (s *S) TestMultiCompleteError(c *check.C) {
+	testServer.Response(200, nil, InitMultiResultDump)
+	// Note the 200 response. Completing will hold the connection on some
+	// kind of long poll, and may return a late error even after a 200.
+	testServer.Response(200, nil, InternalErrorDump)
+
+	b := s.s3.Bucket("sample")
+
+	multi, err := b.InitMulti("multi", "text/plain", s3.Private, s3.Options{})
+	c.Assert(err, check.IsNil)
+
+	err = multi.Complete([]s3.Part{{2, `"ETag2"`, 32}, {1, `"ETag1"`, 64}})
+	c.Assert(err, check.NotNil)
+
+	testServer.WaitRequest()
+	testServer.WaitRequest()
 }
 
 func (s *S) TestMultiAbort(c *check.C) {

--- a/s3/responses_test.go
+++ b/s3/responses_test.go
@@ -194,6 +194,15 @@ var NoSuchUploadErrorDump = `
 </Error>
 `
 
+var MultiCompleteDump = `
+<CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Location>http://Example-Bucket.s3.amazonaws.com/Example-Object</Location>
+  <Bucket>Example-Bucket</Bucket>
+  <Key>Example-Object</Key>
+  <ETag>"3858f62230ac3c915f300c664312c11f-9"</ETag>
+</CompleteMultipartUploadResult>
+`
+
 var InternalErrorDump = `
 <?xml version="1.0" encoding="UTF-8"?>
 <Error>


### PR DESCRIPTION
As described in the comments in the code, and in http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html , not checking the error means that you can lose data if the multipart upload fails to complete... The previous tests had comments hinting that the original author knew that, but that behavior was not handled.