### PR TITLE
s3: Retry on dial errors

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -1251,7 +1251,7 @@ func shouldRetry(err error) bool {
 		return true
 	case *net.OpError:
 		switch e.Op {
-		case "read", "write":
+		case "dial", "read", "write":
 			return true
 		}
 	case *url.Error:


### PR DESCRIPTION
Those kind of errors happen when Dial fails, and Dial errors should be
safe to retry, since no actual API call was done yet.