### PR TITLE
retry request on some 5xx errors

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -1279,6 +1279,10 @@ func shouldRetry(err error) bool {
 		case "InternalError", "NoSuchUpload", "NoSuchBucket":
 			return true
 		}
+		switch e.StatusCode {
+		case 500, 503, 504:
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
amazon can return 503 to indicate that bandwidth exeeded, so it can be nice to have retry.

Added some other 5xx error which make sense to retry in case of receiving.