### PR TITLE
Change EC2Endpoint to a ServiceInfo

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -51,7 +51,7 @@ type ServiceInfo struct {
 // See http://goo.gl/d8BP1 for more details.
 type Region struct {
 	Name                   string // the canonical name of this region.
-	EC2Endpoint            string
+	EC2Endpoint            ServiceInfo
 	S3Endpoint             string
 	S3BucketEndpoint       string // Not needed by AWS S3. Use ${bucket} for bucket name.
 	S3LocationConstraint   bool   // true if this region requires a LocationConstraint declaration.

--- a/aws/regions.go
+++ b/aws/regions.go
@@ -2,7 +2,7 @@ package aws
 
 var USGovWest = Region{
 	"us-gov-west-1",
-	"https://ec2.us-gov-west-1.amazonaws.com",
+	ServiceInfo{"https://ec2.us-gov-west-1.amazonaws.com", V2Signature},
 	"https://s3-fips-us-gov-west-1.amazonaws.com",
 	"",
 	true,
@@ -26,7 +26,7 @@ var USGovWest = Region{
 
 var USEast = Region{
 	"us-east-1",
-	"https://ec2.us-east-1.amazonaws.com",
+	ServiceInfo{"https://ec2.us-east-1.amazonaws.com", V2Signature},
 	"https://s3.amazonaws.com",
 	"",
 	false,
@@ -50,7 +50,7 @@ var USEast = Region{
 
 var USWest = Region{
 	"us-west-1",
-	"https://ec2.us-west-1.amazonaws.com",
+	ServiceInfo{"https://ec2.us-west-1.amazonaws.com", V2Signature},
 	"https://s3-us-west-1.amazonaws.com",
 	"",
 	true,
@@ -74,7 +74,7 @@ var USWest = Region{
 
 var USWest2 = Region{
 	"us-west-2",
-	"https://ec2.us-west-2.amazonaws.com",
+	ServiceInfo{"https://ec2.us-west-2.amazonaws.com", V2Signature},
 	"https://s3-us-west-2.amazonaws.com",
 	"",
 	true,
@@ -98,7 +98,7 @@ var USWest2 = Region{
 
 var EUWest = Region{
 	"eu-west-1",
-	"https://ec2.eu-west-1.amazonaws.com",
+	ServiceInfo{"https://ec2.eu-west-1.amazonaws.com", V2Signature},
 	"https://s3-eu-west-1.amazonaws.com",
 	"",
 	true,
@@ -122,7 +122,7 @@ var EUWest = Region{
 
 var EUCentral = Region{
 	"eu-central-1",
-	"https://ec2.eu-central-1.amazonaws.com",
+	ServiceInfo{"https://ec2.eu-central-1.amazonaws.com", V2Signature},
 	"https://s3-eu-central-1.amazonaws.com",
 	"",
 	true,
@@ -146,7 +146,7 @@ var EUCentral = Region{
 
 var APSoutheast = Region{
 	"ap-southeast-1",
-	"https://ec2.ap-southeast-1.amazonaws.com",
+	ServiceInfo{"https://ec2.ap-southeast-1.amazonaws.com", V2Signature},
 	"https://s3-ap-southeast-1.amazonaws.com",
 	"",
 	true,
@@ -170,7 +170,7 @@ var APSoutheast = Region{
 
 var APSoutheast2 = Region{
 	"ap-southeast-2",
-	"https://ec2.ap-southeast-2.amazonaws.com",
+	ServiceInfo{"https://ec2.ap-southeast-2.amazonaws.com", V2Signature},
 	"https://s3-ap-southeast-2.amazonaws.com",
 	"",
 	true,
@@ -194,7 +194,7 @@ var APSoutheast2 = Region{
 
 var APNortheast = Region{
 	"ap-northeast-1",
-	"https://ec2.ap-northeast-1.amazonaws.com",
+	ServiceInfo{"https://ec2.ap-northeast-1.amazonaws.com", V2Signature},
 	"https://s3-ap-northeast-1.amazonaws.com",
 	"",
 	true,
@@ -218,7 +218,7 @@ var APNortheast = Region{
 
 var SAEast = Region{
 	"sa-east-1",
-	"https://ec2.sa-east-1.amazonaws.com",
+	ServiceInfo{"https://ec2.sa-east-1.amazonaws.com", V2Signature},
 	"https://s3-sa-east-1.amazonaws.com",
 	"",
 	true,
@@ -242,7 +242,7 @@ var SAEast = Region{
 
 var CNNorth1 = Region{
 	"cn-north-1",
-	"https://ec2.cn-north-1.amazonaws.com.cn",
+	ServiceInfo{"https://ec2.cn-north-1.amazonaws.com.cn", V2Signature},
 	"https://s3.cn-north-1.amazonaws.com.cn",
 	"",
 	true,

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -121,7 +121,7 @@ var timeNow = time.Now
 func (ec2 *EC2) query(params map[string]string, resp interface{}) error {
 	params["Version"] = "2014-02-01"
 	params["Timestamp"] = timeNow().In(time.UTC).Format(time.RFC3339)
-	endpoint, err := url.Parse(ec2.Region.EC2Endpoint)
+	endpoint, err := url.Parse(ec2.Region.EC2Endpoint.Endpoint)
 	if err != nil {
 		return err
 	}

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -23,7 +23,7 @@ var testServer = testutil.NewHTTPServer()
 func (s *S) SetUpSuite(c *check.C) {
 	testServer.Start()
 	auth := aws.Auth{AccessKey: "abc", SecretKey: "123"}
-	s.ec2 = ec2.New(auth, aws.Region{EC2Endpoint: testServer.URL})
+	s.ec2 = ec2.New(auth, aws.Region{EC2Endpoint: aws.ServiceInfo{Endpoint: testServer.URL, Signer: aws.V2Signature}})
 }
 
 func (s *S) TearDownTest(c *check.C) {
@@ -964,8 +964,8 @@ func (s *S) TestSignatureWithEndpointPath(c *check.C) {
 
 	testServer.Response(200, nil, RebootInstancesExample)
 
-	// https://bugs.launchpad.net/goamz/+bug/1022749
-	ec2 := ec2.New(s.ec2.Auth, aws.Region{EC2Endpoint: testServer.URL + "/services/Cloud"})
+	region := aws.Region{EC2Endpoint: aws.ServiceInfo{Endpoint: testServer.URL + "/services/Cloud", Signer: aws.V2Signature}}
+	ec2 := ec2.New(s.ec2.Auth, region)
 
 	_, err := ec2.RebootInstances("i-10a64379")
 	c.Assert(err, check.IsNil)

--- a/ec2/ec2t_test.go
+++ b/ec2/ec2t_test.go
@@ -24,7 +24,7 @@ func (s *LocalServer) SetUp(c *check.C) {
 	c.Assert(srv, check.NotNil)
 
 	s.srv = srv
-	s.region = aws.Region{EC2Endpoint: srv.URL()}
+	s.region = aws.Region{EC2Endpoint: aws.ServiceInfo{Endpoint: srv.URL(), Signer: aws.V2Signature}}
 }
 
 // LocalServerSuite defines tests that will run

--- a/elasticache/elasticache_test.go
+++ b/elasticache/elasticache_test.go
@@ -31,7 +31,7 @@ func (s *S) TearDownTest(c *check.C) {
 func (s *S) TestDescribeReplicationGroup(c *check.C) {
 	testServer.Start()
 	auth := aws.Auth{AccessKey: "abc", SecretKey: "123"}
-	s.elasticache = New(auth, aws.Region{EC2Endpoint: testServer.URL})
+	s.elasticache = New(auth, aws.Region{EC2Endpoint: aws.ServiceInfo{Endpoint: testServer.URL, Signer: aws.V2Signature}})
 
 	testServer.Response(200, nil, DescribeReplicationGroupsResponse)
 


### PR DESCRIPTION
This allows specifying a signature version for EC2 authentication.

Some regions e.g. Frankfurt support only signature V4 in EC2 requests. This change is the first step to supporting them there.