### PR TITLE
S3 Compatible:support RadosGW when using goamz in docker registry

### DIFF
--- a/s3/multi.go
+++ b/s3/multi.go
@@ -8,6 +8,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"io"
+	"net/http"
 	"net/url"
 	"sort"
 	"strconv"
@@ -428,6 +429,11 @@ func (m *Multi) Complete(parts []Part) error {
 			payload: bytes.NewReader(data),
 		}
 		var resp completeUploadResp
+		if m.Bucket.Region.Name == "generic" {
+			headers := make(http.Header)
+			headers.Add("Content-Length", strconv.FormatInt(int64(len(data)), 10))
+			req.headers = headers
+		}
 		err := m.Bucket.S3.query(req, &resp)
 		if shouldRetry(err) && attempt.HasNext() {
 			continue

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -1111,7 +1111,9 @@ func (s3 *S3) setupHttpRequest(req *request) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	u.Opaque = fmt.Sprintf("//%s%s", u.Host, partiallyEscapedPath(u.Path))
+	if s3.Region.Name != "generic" {
+		u.Opaque = fmt.Sprintf("//%s%s", u.Host, partiallyEscapedPath(u.Path))
+	}
 
 	hreq := http.Request{
 		URL:        u,


### PR DESCRIPTION
This pull request aims to S3 Compatible, associate with pull request docker/distribution#902 
This pull request fix two problem:

- send Relative URI instead of Absolute URI when working with RadosGW  (mentioned by https://github.com/AdRoll/goamz/issues/386 and https://github.com/aws/aws-sdk-go/issues/344 )
- complete upload multiple part add http header content-length when working with RadosGW(needed by RadosGW)

ps : when using "generic" as region name indicate that working with RadosGW