### PR TITLE
Use Temporary Security Credentials

### DIFF
--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -173,6 +173,10 @@ func (k *Kinesis) query(target string, query *Query) ([]byte, error) {
 	hreq.Header.Set("X-Amz-Date", time.Now().UTC().Format(aws.ISO8601BasicFormat))
 	hreq.Header.Set("X-Amz-Target", target)
 
+	if k.Auth.Token() != "" {
+		hreq.Header.Set("X-Amz-Security-Token", k.Auth.Token())
+	}
+
 	signer := aws.NewV4Signer(k.Auth, "kinesis", k.Region)
 	signer.Sign(hreq)
 


### PR DESCRIPTION
Set the X-Amz-Security-Token header, same as many others:

https://github.com/AdRoll/goamz/search?utf8=%E2%9C%93&q=X-Amz-Security-Token