### PR TITLE
s3: Use the s3-external-1 endpoint for US East

### DIFF
--- a/aws/regions.go
+++ b/aws/regions.go
@@ -27,7 +27,7 @@ var USGovWest = Region{
 var USEast = Region{
 	"us-east-1",
 	ServiceInfo{"https://ec2.us-east-1.amazonaws.com", V2Signature},
-	"https://s3.amazonaws.com",
+	"https://s3-external-1.amazonaws.com",
 	"",
 	false,
 	false,


### PR DESCRIPTION
That endpoint is the same functionally as s3.amazonaws.com, but
guarantees read-after-write consistency, as mentioned in
https://forums.aws.amazon.com/ann.jspa?annID=3112 .