### PR TITLE
s3: PostFormArgs sets `x-amz-security-token` form value for session c…

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -886,6 +886,12 @@ func (b *Bucket) PostFormArgsEx(path string, expires time.Time, redirect string,
 		"key":            path,
 	}
 
+	if token := b.S3.Auth.Token(); token != "" {
+		fields["x-amz-security-token"] = token
+		conditions = append(conditions,
+			fmt.Sprintf("{\"x-amz-security-token\": \"%s\"}", token))
+	}
+
 	if conds != nil {
 		conditions = append(conditions, conds...)
 	}


### PR DESCRIPTION
`PostFormArgs` and `PostFormArgsEx` should pass the token when the session credentials are used. Just as it is done for signed URLs, and any HTTP API request.