### PR TITLE
ses: support SES notifications for received emails

### DIFF
--- a/exp/ses/delivery_notification.go
+++ b/exp/ses/delivery_notification.go
@@ -5,10 +5,12 @@ import (
 )
 
 //http://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html#top-level-json-object
+//http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-notifications-contents.html
 const (
 	NOTIFICATION_TYPE_BOUNCE    = "Bounce"
 	NOTIFICATION_TYPE_COMPLAINT = "Complaint"
 	NOTIFICATION_TYPE_DELIVERY  = "Delivery"
+	NOTIFICATION_TYPE_RECEIVED  = "Received"
 
 	//http://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html#bounce-types
 	BOUNCE_TYPE_UNDETERMINED           = "Undetermined"
@@ -30,22 +32,54 @@ const (
 	COMPLAINT_FEEDBACK_TYPE_NOT_SPAM     = "not-spam"
 	COMPLAINT_FEEDBACK_TYPE_OTHER        = "other"
 	COMPLAINT_FEEDBACK_TYPE_VIRUS        = "virus"
+
+	// http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-notifications-contents.html#receiving-email-notifications-contents-dkimverdict-object
+	VERDICT_STATUS_PASS              = "PASS"
+	VERDICT_STATUS_FAIL              = "FAIL"
+	VERDICT_STATUS_GRAY              = "GRAY"
+	VERDICT_STATUS_PROCESSING_FAILED = "PROCESSING_FAILED"
+
+	RECEIPT_ACTION_S3        = "S3"
+	RECEIPT_ACTION_SNS       = "SNS"
+	RECEIPT_ACTION_BOUNCE    = "Bounce"
+	RECEIPT_ACTION_LAMBDA    = "Lambda"
+	RECEIPT_ACTION_STOP      = "Stop"
+	RECEIPT_ACTION_WORK_MAIL = "WorkMail"
 )
 
 type SNSNotification struct {
 	NotificationType string     `json:"notificationType"`
-	Bounce           *Bounce    `json:"bounce" optional`
-	Complaint        *Complaint `json:"complaint" optional`
-	Delivery         *Delivery  `json:"delivery" optional`
+	Bounce           *Bounce    `json:"bounce,omitempty"`
+	Complaint        *Complaint `json:"complaint,omitempty"`
+	Delivery         *Delivery  `json:"delivery,omitempty"`
+	Receipt          *Receipt   `json:"receipt,omitempty"`
+	Content          *string    `json:"content,omitempty"`
 	Mail             *Mail      `json:"mail"`
+}
+
+type MailHeader struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type CommonHeaders struct {
+	MessageId  string   `json:"messageId"`
+	To         []string `json:"to"`
+	From       []string `json:"from"`
+	ReturnPath string   `json:"returnPath"`
+	Date       string   `json:"date"`
+	Subject    string   `json:"subject"`
 }
 
 // Represent the delivery of an email
 type Mail struct {
-	Timestamp   time.Time `json:"timestamp"`
-	MessageId   string    `json:"messageId"`
-	Source      string    `json:"source"`
-	Destination []string  `json:"destination"`
+	Timestamp        time.Time      `json:"timestamp"`
+	MessageId        string         `json:"messageId"`
+	Source           string         `json:"source"`
+	Destination      []string       `json:"destination"`
+	Headers          []MailHeader   `json:"headers,omitempty"`
+	CommonHeaders    *CommonHeaders `json:"commonHeaders,omitempty"`
+	HeadersTruncated bool           `json:"headersTruncated,omitempty"`
 }
 
 // A bounced recipient
@@ -93,4 +127,35 @@ type Delivery struct {
 	Recipients           []string  `json:"recipients"`
 	SmtpResponse         string    `json:"smtpResponse"`
 	ReportingMTA         string    `json:"reportingMTA"`
+}
+
+type CheckVerdict struct {
+	Status string `json:"status"`
+}
+
+type ReceiptAction struct {
+	Type            string `json:"type"`
+	TopicArn        string `json:"topicArn"`
+	BucketName      string `json:"bucketName,omitempty"`
+	ObjectKey       string `json:"objectKey,omitempty"`
+	SmtpReplyCode   string `json:"smtpReplyCode,omitempty"`
+	StatusCode      string `json:"statusCode,omitempty"`
+	Message         string `json:"message,omitempty"`
+	Sender          string `json:"sender,omitempty"`
+	FunctionArn     string `json:"functionArn,omitempty"`
+	InvocationType  string `json:"invocationType,omitempty"`
+	OrganizationArn string `json:"organizationArn,omitempty"`
+}
+
+// A receipt event
+// http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-notifications-contents.html#receiving-email-notifications-contents-receipt-object
+type Receipt struct {
+	Action               ReceiptAction `json:"action"`
+	Timestamp            time.Time     `json:"timestamp"`
+	ProcessingTimeMillis int64         `json:"processingTimeMillis"`
+	Recipients           []string      `json:"recipients"`
+	DkimVerdict          CheckVerdict  `json:"dkimVerdict"`
+	SpamVerdict          CheckVerdict  `json:"spamVerdict"`
+	SpfVerdict           CheckVerdict  `json:"spfVerdict"`
+	VirusVerdict         CheckVerdict  `json:"virusVerdict"`
 }

--- a/exp/ses/delivery_notification_requests_test.go
+++ b/exp/ses/delivery_notification_requests_test.go
@@ -79,3 +79,212 @@ const SNSDeliveryNotification = `
       } 
    }
 `
+
+const SNSReceiptAlertNotification = `{
+    "notificationType": "Received",
+    "receipt": {
+        "timestamp": "2015-09-11T20:32:33.936Z",
+        "processingTimeMillis": 406,
+        "recipients": [
+            "recipient@example.com"
+        ],
+        "spamVerdict": {
+            "status": "PASS"
+        },
+        "virusVerdict": {
+            "status": "PASS"
+        },
+        "spfVerdict": {
+            "status": "PASS"
+        },
+        "dkimVerdict": {
+            "status": "PASS"
+        },
+        "action": {
+            "type": "S3",
+            "topicArn": "arn:aws:sns:us-east-1:012345678912:example-topic",
+            "bucketName": "my-S3-bucket",
+            "objectKey": "\\email"
+        }
+    },
+    "mail": {
+        "timestamp": "2015-09-11T20:32:33.936Z",
+        "source": "0000014fbe1c09cf-7cb9f704-7531-4e53-89a1-5fa9744f5eb6-000000@amazonses.com",
+        "messageId": "d6iitobk75ur44p8kdnnp7g2n800",
+        "destination": [
+            "recipient@example.com"
+        ],
+        "headersTruncated": false,
+        "headers": [
+            {
+                "name": "Return-Path",
+                "value": "<0000014fbe1c09cf-7cb9f704-7531-4e53-89a1-5fa9744f5eb6-000000@amazonses.com>"
+            },
+            {
+                "name": "Received",
+                "value": "from a9-183.smtp-out.amazonses.com (a9-183.smtp-out.amazonses.com [54.240.9.183]) by inbound-smtp.us-east-1.amazonaws.com with SMTP id d6iitobk75ur44p8kdnnp7g2n800 for recipient@example.com; Fri, 11 Sep 2015 20:32:33 +0000 (UTC)"
+            },
+            {
+                "name": "DKIM-Signature",
+                "value": "v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple; s=ug7nbtf4gccmlpwj322ax3p6ow6yfsug; d=amazonses.com; t=1442003552; h=From:To:Subject:MIME-Version:Content-Type:Content-Transfer-Encoding:Date:Message-ID:Feedback-ID; bh=DWr3IOmYWoXCA9ARqGC/UaODfghffiwFNRIb2Mckyt4=; b=p4ukUDSFqhqiub+zPR0DW1kp7oJZakrzupr6LBe6sUuvqpBkig56UzUwc29rFbJF hlX3Ov7DeYVNoN38stqwsF8ivcajXpQsXRC1cW9z8x875J041rClAjV7EGbLmudVpPX 4hHst1XPyX5wmgdHIhmUuh8oZKpVqGi6bHGzzf7g="
+            },
+            {
+                "name": "From",
+                "value": "sender@example.com"
+            },
+            {
+                "name": "To",
+                "value": "recipient@example.com"
+            },
+            {
+                "name": "Subject",
+                "value": "Example subject"
+            },
+            {
+                "name": "MIME-Version",
+                "value": "1.0"
+            },
+            {
+                "name": "Content-Type",
+                "value": "text/plain; charset=UTF-8"
+            },
+            {
+                "name": "Content-Transfer-Encoding",
+                "value": "7bit"
+            },
+            {
+                "name": "Date",
+                "value": "Fri, 11 Sep 2015 20:32:32 +0000"
+            },
+            {
+                "name": "Message-ID",
+                "value": "<61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com>"
+            },
+            {
+                "name": "X-SES-Outgoing",
+                "value": "2015.09.11-54.240.9.183"
+            },
+            {
+                "name": "Feedback-ID",
+                "value": "1.us-east-1.Krv2FKpFdWV+KUYw3Qd6wcpPJ4Sv/pOPpEPSHn2u2o4=:AmazonSES"
+            }
+        ],
+        "commonHeaders": {
+            "returnPath": "0000014fbe1c09cf-7cb9f704-7531-4e53-89a1-5fa9744f5eb6-000000@amazonses.com",
+            "from": [
+                "sender@example.com"
+            ],
+            "date": "Fri, 11 Sep 2015 20:32:32 +0000",
+            "to": [
+                "recipient@example.com"
+            ],
+            "messageId": "<61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com>",
+            "subject": "Example subject"
+        }
+    }
+}`
+
+const SNSReceiptNotification = `{
+    "notificationType": "Received",
+    "receipt": {
+        "timestamp": "2015-09-11T20:32:33.936Z",
+        "processingTimeMillis": 222,
+        "recipients": [
+            "recipient@example.com"
+        ],
+        "spamVerdict": {
+            "status": "PASS"
+        },
+        "virusVerdict": {
+            "status": "PASS"
+        },
+        "spfVerdict": {
+            "status": "PASS"
+        },
+        "dkimVerdict": {
+            "status": "PASS"
+        },
+        "action": {
+            "type": "SNS",
+            "topicArn": "arn:aws:sns:us-east-1:012345678912:example-topic"
+        }
+    },
+    "mail": {
+        "timestamp": "2015-09-11T20:32:33.936Z",
+        "source": "61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com",
+        "messageId": "d6iitobk75ur44p8kdnnp7g2n800",
+        "destination": [
+            "recipient@example.com"
+        ],
+        "headersTruncated": false,
+        "headers": [
+            {
+                "name": "Return-Path",
+                "value": "<0000014fbe1c09cf-7cb9f704-7531-4e53-89a1-5fa9744f5eb6-000000@amazonses.com>"
+            },
+            {
+                "name": "Received",
+                "value": "from a9-183.smtp-out.amazonses.com (a9-183.smtp-out.amazonses.com [54.240.9.183]) by inbound-smtp.us-east-1.amazonaws.com with SMTP id d6iitobk75ur44p8kdnnp7g2n800 for recipient@example.com; Fri, 11 Sep 2015 20:32:33 +0000 (UTC)"
+            },
+            {
+                "name": "DKIM-Signature",
+                "value": "v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple; s=ug7nbtf4gccmlpwj322ax3p6ow6yfsug; d=amazonses.com; t=1442003552; h=From:To:Subject:MIME-Version:Content-Type:Content-Transfer-Encoding:Date:Message-ID:Feedback-ID; bh=DWr3IOmYWoXCA9ARqGC/UaODfghffiwFNRIb2Mckyt4=; b=p4ukUDSFqhqiub+zPR0DW1kp7oJZakrzupr6LBe6sUuvqpBkig56UzUwc29rFbJF hlX3Ov7DeYVNoN38stqwsF8ivcajXpQsXRC1cW9z8x875J041rClAjV7EGbLmudVpPX 4hHst1XPyX5wmgdHIhmUuh8oZKpVqGi6bHGzzf7g="
+            },
+            {
+                "name": "From",
+                "value": "sender@example.com"
+            },
+            {
+                "name": "To",
+                "value": "recipient@example.com"
+            },
+            {
+                "name": "Subject",
+                "value": "Example subject"
+            },
+            {
+                "name": "MIME-Version",
+                "value": "1.0"
+            },
+            {
+                "name": "Content-Type",
+                "value": "text/plain; charset=UTF-8"
+            },
+            {
+                "name": "Content-Transfer-Encoding",
+                "value": "7bit"
+            },
+            {
+                "name": "Date",
+                "value": "Fri, 11 Sep 2015 20:32:32 +0000"
+            },
+            {
+                "name": "Message-ID",
+                "value": "<61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com>"
+            },
+            {
+                "name": "X-SES-Outgoing",
+                "value": "2015.09.11-54.240.9.183"
+            },
+            {
+                "name": "Feedback-ID",
+                "value": "1.us-east-1.Krv2FKpFdWV+KUYw3Qd6wcpPJ4Sv/pOPpEPSHn2u2o4=:AmazonSES"
+            }
+        ],
+        "commonHeaders": {
+            "returnPath": "0000014fbe1c09cf-7cb9f704-7531-4e53-89a1-5fa9744f5eb6-000000@amazonses.com",
+            "from": [
+                "sender@example.com"
+            ],
+            "date": "Fri, 11 Sep 2015 20:32:32 +0000",
+            "to": [
+                "recipient@example.com"
+            ],
+            "messageId": "<61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com>",
+            "subject": "Example subject"
+        }
+    },
+    "content": "Return-Path: <61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com>\r\nReceived: from a9-183.smtp-out.amazonses.com (a9-183.smtp-out.amazonses.com [54.240.9.183])\r\n by inbound-smtp.us-east-1.amazonaws.com with SMTP id d6iitobk75ur44p8kdnnp7g2n800\r\n for recipient@example.com;\r\n Fri, 11 Sep 2015 20:32:33 +0000 (UTC)\r\nDKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple;\r\n\ts=ug7nbtf4gccmlpwj322ax3p6ow6yfsug; d=amazonses.com; t=1442003552;\r\n\th=From:To:Subject:MIME-Version:Content-Type:Content-Transfer-Encoding:Date:Message-ID:Feedback-ID;\r\n\tbh=DWr3IOmYWoXCA9ARqGC/UaODfghffiwFNRIb2Mckyt4=;\r\n\tb=p4ukUDSFqhqiub+zPR0DW1kp7oJZakrzupr6LBe6sUuvqpBkig56UzUwc29rFbJF\r\n\thlX3Ov7DeYVNoN38stqwsF8ivcajXpQsXRC1cW9z8x875J041rClAjV7EGbLmudVpPX\r\n\t4hHst1XPyX5wmgdHIhmUuh8oZKpVqGi6bHGzzf7g=\r\nFrom: sender@example.com\r\nTo: recipient@example.com\r\nSubject: Example subject\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\nDate: Fri, 11 Sep 2015 20:32:32 +0000\r\nMessage-ID: <61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com>\r\nX-SES-Outgoing: 2015.09.11-54.240.9.183\r\nFeedback-ID: 1.us-east-1.Krv2FKpFdWV+KUYw3Qd6wcpPJ4Sv/pOPpEPSHn2u2o4=:AmazonSES\r\n\r\nExample content\r\n"
+}`
+
+const SNSReceiptNotificationContent = "Return-Path: <61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com>\r\nReceived: from a9-183.smtp-out.amazonses.com (a9-183.smtp-out.amazonses.com [54.240.9.183])\r\n by inbound-smtp.us-east-1.amazonaws.com with SMTP id d6iitobk75ur44p8kdnnp7g2n800\r\n for recipient@example.com;\r\n Fri, 11 Sep 2015 20:32:33 +0000 (UTC)\r\nDKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple;\r\n\ts=ug7nbtf4gccmlpwj322ax3p6ow6yfsug; d=amazonses.com; t=1442003552;\r\n\th=From:To:Subject:MIME-Version:Content-Type:Content-Transfer-Encoding:Date:Message-ID:Feedback-ID;\r\n\tbh=DWr3IOmYWoXCA9ARqGC/UaODfghffiwFNRIb2Mckyt4=;\r\n\tb=p4ukUDSFqhqiub+zPR0DW1kp7oJZakrzupr6LBe6sUuvqpBkig56UzUwc29rFbJF\r\n\thlX3Ov7DeYVNoN38stqwsF8ivcajXpQsXRC1cW9z8x875J041rClAjV7EGbLmudVpPX\r\n\t4hHst1XPyX5wmgdHIhmUuh8oZKpVqGi6bHGzzf7g=\r\nFrom: sender@example.com\r\nTo: recipient@example.com\r\nSubject: Example subject\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\nDate: Fri, 11 Sep 2015 20:32:32 +0000\r\nMessage-ID: <61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com>\r\nX-SES-Outgoing: 2015.09.11-54.240.9.183\r\nFeedback-ID: 1.us-east-1.Krv2FKpFdWV+KUYw3Qd6wcpPJ4Sv/pOPpEPSHn2u2o4=:AmazonSES\r\n\r\nExample content\r\n"

--- a/exp/ses/delivery_notification_test.go
+++ b/exp/ses/delivery_notification_test.go
@@ -25,6 +25,9 @@ func (s *S) TestSNSBounceNotificationUnmarshalling(c *check.C) {
 		"00000138111222aa-33322211-cccc-cccc-cccc-ddddaaaa0680-000000")
 	c.Assert(notification.Mail.Destination, check.DeepEquals,
 		[]string{"username@example.com"})
+	c.Assert(notification.Mail.HeadersTruncated, check.Equals, false)
+	c.Assert(notification.Mail.CommonHeaders, check.IsNil)
+	c.Assert(notification.Mail.Headers, check.HasLen, 0)
 
 	c.Assert(notification.Bounce, check.NotNil)
 	c.Assert(notification.Bounce.BounceType, check.Equals,
@@ -50,6 +53,10 @@ func (s *S) TestSNSBounceNotificationUnmarshalling(c *check.C) {
 	c.Assert(notification.Complaint, check.IsNil)
 
 	c.Assert(notification.Delivery, check.IsNil)
+
+	c.Assert(notification.Receipt, check.IsNil)
+
+	c.Assert(notification.Content, check.IsNil)
 }
 
 func (s *S) TestSNSComplaintNotificationUnmarshalling(c *check.C) {
@@ -71,6 +78,9 @@ func (s *S) TestSNSComplaintNotificationUnmarshalling(c *check.C) {
 	c.Assert(notification.Mail.Destination, check.DeepEquals,
 		[]string{"recipient1@example.com", "recipient2@example.com",
 			"recipient3@example.com", "recipient4@example.com"})
+	c.Assert(notification.Mail.HeadersTruncated, check.Equals, false)
+	c.Assert(notification.Mail.CommonHeaders, check.IsNil)
+	c.Assert(notification.Mail.Headers, check.HasLen, 0)
 
 	c.Assert(notification.Bounce, check.IsNil)
 
@@ -93,6 +103,10 @@ func (s *S) TestSNSComplaintNotificationUnmarshalling(c *check.C) {
 		})
 
 	c.Assert(notification.Delivery, check.IsNil)
+
+	c.Assert(notification.Receipt, check.IsNil)
+
+	c.Assert(notification.Content, check.IsNil)
 }
 
 func (s *S) TestSNSDeliveryNotificationUnmarshalling(c *check.C) {
@@ -113,6 +127,9 @@ func (s *S) TestSNSDeliveryNotificationUnmarshalling(c *check.C) {
 	c.Assert(notification.Mail.Destination, check.DeepEquals,
 		[]string{"success@simulator.amazonses.com",
 			"recipient@ses-example.com"})
+	c.Assert(notification.Mail.HeadersTruncated, check.Equals, false)
+	c.Assert(notification.Mail.CommonHeaders, check.IsNil)
+	c.Assert(notification.Mail.Headers, check.HasLen, 0)
 
 	c.Assert(notification.Bounce, check.IsNil)
 
@@ -129,6 +146,240 @@ func (s *S) TestSNSDeliveryNotificationUnmarshalling(c *check.C) {
 		"250 ok:  Message 64111812 accepted")
 	c.Assert(notification.Delivery.Recipients, check.DeepEquals,
 		[]string{"success@simulator.amazonses.com"})
+
+	c.Assert(notification.Receipt, check.IsNil)
+
+	c.Assert(notification.Content, check.IsNil)
+}
+
+func (s *S) TestSNSReceiptAlertNotificationUnmarshalling(c *check.C) {
+	notification := ses.SNSNotification{}
+	err := json.Unmarshal([]byte(SNSReceiptAlertNotification), &notification)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(notification.NotificationType, check.Equals,
+		ses.NOTIFICATION_TYPE_RECEIVED)
+
+	c.Assert(notification.Mail, check.NotNil)
+	c.Assert(notification.Mail.Timestamp, check.DeepEquals,
+		parseJsonTime("2015-09-11T20:32:33.936Z"))
+	c.Assert(notification.Mail.Source, check.Equals,
+		"0000014fbe1c09cf-7cb9f704-7531-4e53-89a1-5fa9744f5eb6-000000@amazonses.com")
+	c.Assert(notification.Mail.MessageId, check.Equals,
+		"d6iitobk75ur44p8kdnnp7g2n800")
+	c.Assert(notification.Mail.Destination, check.DeepEquals,
+		[]string{"recipient@example.com"})
+	c.Assert(notification.Mail.HeadersTruncated, check.Equals, false)
+	c.Assert(notification.Mail.CommonHeaders, check.DeepEquals, &ses.CommonHeaders{
+		MessageId:  "<61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com>",
+		To:         []string{"recipient@example.com"},
+		From:       []string{"sender@example.com"},
+		ReturnPath: "0000014fbe1c09cf-7cb9f704-7531-4e53-89a1-5fa9744f5eb6-000000@amazonses.com",
+		Date:       "Fri, 11 Sep 2015 20:32:32 +0000",
+		Subject:    "Example subject",
+	})
+	c.Assert(notification.Mail.Headers, check.HasLen, 13)
+	c.Assert(notification.Mail.Headers[0], check.Equals, ses.MailHeader{
+		"Return-Path",
+		"<0000014fbe1c09cf-7cb9f704-7531-4e53-89a1-5fa9744f5eb6-000000@amazonses.com>",
+	})
+	c.Assert(notification.Mail.Headers[1], check.Equals, ses.MailHeader{
+		"Received",
+		"from a9-183.smtp-out.amazonses.com (a9-183.smtp-out.amazonses.com [54.240.9.183]) by inbound-smtp.us-east-1.amazonaws.com with SMTP id d6iitobk75ur44p8kdnnp7g2n800 for recipient@example.com; Fri, 11 Sep 2015 20:32:33 +0000 (UTC)",
+	})
+	c.Assert(notification.Mail.Headers[2], check.Equals, ses.MailHeader{
+		"DKIM-Signature",
+		"v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple; s=ug7nbtf4gccmlpwj322ax3p6ow6yfsug; d=amazonses.com; t=1442003552; h=From:To:Subject:MIME-Version:Content-Type:Content-Transfer-Encoding:Date:Message-ID:Feedback-ID; bh=DWr3IOmYWoXCA9ARqGC/UaODfghffiwFNRIb2Mckyt4=; b=p4ukUDSFqhqiub+zPR0DW1kp7oJZakrzupr6LBe6sUuvqpBkig56UzUwc29rFbJF hlX3Ov7DeYVNoN38stqwsF8ivcajXpQsXRC1cW9z8x875J041rClAjV7EGbLmudVpPX 4hHst1XPyX5wmgdHIhmUuh8oZKpVqGi6bHGzzf7g=",
+	})
+	c.Assert(notification.Mail.Headers[3], check.Equals, ses.MailHeader{
+		"From",
+		"sender@example.com",
+	})
+	c.Assert(notification.Mail.Headers[4], check.Equals, ses.MailHeader{
+		"To",
+		"recipient@example.com",
+	})
+	c.Assert(notification.Mail.Headers[5], check.Equals, ses.MailHeader{
+		"Subject",
+		"Example subject",
+	})
+	c.Assert(notification.Mail.Headers[6], check.Equals, ses.MailHeader{
+		"MIME-Version",
+		"1.0",
+	})
+	c.Assert(notification.Mail.Headers[7], check.Equals, ses.MailHeader{
+		"Content-Type",
+		"text/plain; charset=UTF-8",
+	})
+	c.Assert(notification.Mail.Headers[8], check.Equals, ses.MailHeader{
+		"Content-Transfer-Encoding",
+		"7bit",
+	})
+	c.Assert(notification.Mail.Headers[9], check.Equals, ses.MailHeader{
+		"Date",
+		"Fri, 11 Sep 2015 20:32:32 +0000",
+	})
+	c.Assert(notification.Mail.Headers[10], check.Equals, ses.MailHeader{
+		"Message-ID",
+		"<61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com>",
+	})
+	c.Assert(notification.Mail.Headers[11], check.Equals, ses.MailHeader{
+		"X-SES-Outgoing",
+		"2015.09.11-54.240.9.183",
+	})
+	c.Assert(notification.Mail.Headers[12], check.Equals, ses.MailHeader{
+		"Feedback-ID",
+		"1.us-east-1.Krv2FKpFdWV+KUYw3Qd6wcpPJ4Sv/pOPpEPSHn2u2o4=:AmazonSES",
+	})
+
+	c.Assert(notification.Bounce, check.IsNil)
+
+	c.Assert(notification.Complaint, check.IsNil)
+
+	c.Assert(notification.Delivery, check.IsNil)
+
+	c.Assert(notification.Receipt, check.NotNil)
+	c.Assert(notification.Receipt.Timestamp, check.DeepEquals,
+		parseJsonTime("2015-09-11T20:32:33.936Z"))
+	c.Assert(notification.Receipt.ProcessingTimeMillis, check.Equals, int64(406))
+	c.Assert(notification.Receipt.Recipients, check.DeepEquals, []string{
+		"recipient@example.com",
+	})
+	c.Assert(notification.Receipt.DkimVerdict.Status, check.Equals, "PASS")
+	c.Assert(notification.Receipt.SpamVerdict.Status, check.Equals, "PASS")
+	c.Assert(notification.Receipt.SpfVerdict.Status, check.Equals, "PASS")
+	c.Assert(notification.Receipt.VirusVerdict.Status, check.Equals, "PASS")
+	c.Assert(notification.Receipt.Action.Type, check.Equals,
+		ses.RECEIPT_ACTION_S3)
+	c.Assert(notification.Receipt.Action.TopicArn, check.Equals,
+		"arn:aws:sns:us-east-1:012345678912:example-topic")
+	c.Assert(notification.Receipt.Action.BucketName, check.Equals,
+		"my-S3-bucket")
+	c.Assert(notification.Receipt.Action.ObjectKey, check.Equals, "\\email")
+	c.Assert(notification.Receipt.Action.SmtpReplyCode, check.Equals, "")
+	c.Assert(notification.Receipt.Action.StatusCode, check.Equals, "")
+	c.Assert(notification.Receipt.Action.Message, check.Equals, "")
+	c.Assert(notification.Receipt.Action.Sender, check.Equals, "")
+	c.Assert(notification.Receipt.Action.FunctionArn, check.Equals, "")
+	c.Assert(notification.Receipt.Action.InvocationType, check.Equals, "")
+	c.Assert(notification.Receipt.Action.OrganizationArn, check.Equals, "")
+
+	c.Assert(notification.Content, check.IsNil)
+}
+
+func (s *S) TestSNSReceiptNotificationUnmarshalling(c *check.C) {
+	notification := ses.SNSNotification{}
+	err := json.Unmarshal([]byte(SNSReceiptNotification), &notification)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(notification.NotificationType, check.Equals,
+		ses.NOTIFICATION_TYPE_RECEIVED)
+
+	c.Assert(notification.Mail, check.NotNil)
+	c.Assert(notification.Mail.Timestamp, check.DeepEquals,
+		parseJsonTime("2015-09-11T20:32:33.936Z"))
+	c.Assert(notification.Mail.Source, check.Equals,
+		"61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com")
+	c.Assert(notification.Mail.MessageId, check.Equals,
+		"d6iitobk75ur44p8kdnnp7g2n800")
+	c.Assert(notification.Mail.Destination, check.DeepEquals,
+		[]string{"recipient@example.com"})
+	c.Assert(notification.Mail.HeadersTruncated, check.Equals, false)
+	c.Assert(notification.Mail.CommonHeaders, check.DeepEquals, &ses.CommonHeaders{
+		MessageId:  "<61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com>",
+		To:         []string{"recipient@example.com"},
+		From:       []string{"sender@example.com"},
+		ReturnPath: "0000014fbe1c09cf-7cb9f704-7531-4e53-89a1-5fa9744f5eb6-000000@amazonses.com",
+		Date:       "Fri, 11 Sep 2015 20:32:32 +0000",
+		Subject:    "Example subject",
+	})
+	c.Assert(notification.Mail.Headers, check.HasLen, 13)
+	c.Assert(notification.Mail.Headers[0], check.Equals, ses.MailHeader{
+		"Return-Path",
+		"<0000014fbe1c09cf-7cb9f704-7531-4e53-89a1-5fa9744f5eb6-000000@amazonses.com>",
+	})
+	c.Assert(notification.Mail.Headers[1], check.Equals, ses.MailHeader{
+		"Received",
+		"from a9-183.smtp-out.amazonses.com (a9-183.smtp-out.amazonses.com [54.240.9.183]) by inbound-smtp.us-east-1.amazonaws.com with SMTP id d6iitobk75ur44p8kdnnp7g2n800 for recipient@example.com; Fri, 11 Sep 2015 20:32:33 +0000 (UTC)",
+	})
+	c.Assert(notification.Mail.Headers[2], check.Equals, ses.MailHeader{
+		"DKIM-Signature",
+		"v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple; s=ug7nbtf4gccmlpwj322ax3p6ow6yfsug; d=amazonses.com; t=1442003552; h=From:To:Subject:MIME-Version:Content-Type:Content-Transfer-Encoding:Date:Message-ID:Feedback-ID; bh=DWr3IOmYWoXCA9ARqGC/UaODfghffiwFNRIb2Mckyt4=; b=p4ukUDSFqhqiub+zPR0DW1kp7oJZakrzupr6LBe6sUuvqpBkig56UzUwc29rFbJF hlX3Ov7DeYVNoN38stqwsF8ivcajXpQsXRC1cW9z8x875J041rClAjV7EGbLmudVpPX 4hHst1XPyX5wmgdHIhmUuh8oZKpVqGi6bHGzzf7g=",
+	})
+	c.Assert(notification.Mail.Headers[3], check.Equals, ses.MailHeader{
+		"From",
+		"sender@example.com",
+	})
+	c.Assert(notification.Mail.Headers[4], check.Equals, ses.MailHeader{
+		"To",
+		"recipient@example.com",
+	})
+	c.Assert(notification.Mail.Headers[5], check.Equals, ses.MailHeader{
+		"Subject",
+		"Example subject",
+	})
+	c.Assert(notification.Mail.Headers[6], check.Equals, ses.MailHeader{
+		"MIME-Version",
+		"1.0",
+	})
+	c.Assert(notification.Mail.Headers[7], check.Equals, ses.MailHeader{
+		"Content-Type",
+		"text/plain; charset=UTF-8",
+	})
+	c.Assert(notification.Mail.Headers[8], check.Equals, ses.MailHeader{
+		"Content-Transfer-Encoding",
+		"7bit",
+	})
+	c.Assert(notification.Mail.Headers[9], check.Equals, ses.MailHeader{
+		"Date",
+		"Fri, 11 Sep 2015 20:32:32 +0000",
+	})
+	c.Assert(notification.Mail.Headers[10], check.Equals, ses.MailHeader{
+		"Message-ID",
+		"<61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com>",
+	})
+	c.Assert(notification.Mail.Headers[11], check.Equals, ses.MailHeader{
+		"X-SES-Outgoing",
+		"2015.09.11-54.240.9.183",
+	})
+	c.Assert(notification.Mail.Headers[12], check.Equals, ses.MailHeader{
+		"Feedback-ID",
+		"1.us-east-1.Krv2FKpFdWV+KUYw3Qd6wcpPJ4Sv/pOPpEPSHn2u2o4=:AmazonSES",
+	})
+
+	c.Assert(notification.Bounce, check.IsNil)
+
+	c.Assert(notification.Complaint, check.IsNil)
+
+	c.Assert(notification.Delivery, check.IsNil)
+
+	c.Assert(notification.Receipt, check.NotNil)
+	c.Assert(notification.Receipt.Timestamp, check.DeepEquals,
+		parseJsonTime("2015-09-11T20:32:33.936Z"))
+	c.Assert(notification.Receipt.ProcessingTimeMillis, check.Equals, int64(222))
+	c.Assert(notification.Receipt.Recipients, check.DeepEquals, []string{
+		"recipient@example.com",
+	})
+	c.Assert(notification.Receipt.DkimVerdict.Status, check.Equals, "PASS")
+	c.Assert(notification.Receipt.SpamVerdict.Status, check.Equals, "PASS")
+	c.Assert(notification.Receipt.SpfVerdict.Status, check.Equals, "PASS")
+	c.Assert(notification.Receipt.VirusVerdict.Status, check.Equals, "PASS")
+	c.Assert(notification.Receipt.Action.Type, check.Equals,
+		ses.RECEIPT_ACTION_SNS)
+	c.Assert(notification.Receipt.Action.TopicArn, check.Equals,
+		"arn:aws:sns:us-east-1:012345678912:example-topic")
+	c.Assert(notification.Receipt.Action.BucketName, check.Equals, "")
+	c.Assert(notification.Receipt.Action.ObjectKey, check.Equals, "")
+	c.Assert(notification.Receipt.Action.SmtpReplyCode, check.Equals, "")
+	c.Assert(notification.Receipt.Action.StatusCode, check.Equals, "")
+	c.Assert(notification.Receipt.Action.Message, check.Equals, "")
+	c.Assert(notification.Receipt.Action.Sender, check.Equals, "")
+	c.Assert(notification.Receipt.Action.FunctionArn, check.Equals, "")
+	c.Assert(notification.Receipt.Action.InvocationType, check.Equals, "")
+	c.Assert(notification.Receipt.Action.OrganizationArn, check.Equals, "")
+
+	c.Assert(notification.Content, check.NotNil)
+	c.Assert(*notification.Content, check.Equals, SNSReceiptNotificationContent)
 }
 
 func parseJsonTime(str string) time.Time {


### PR DESCRIPTION
The event adds support for SNS notifications of received emails.

See http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-notifications.html

I've decided to extend the already-defined `SNSNotification` structure, since the notification object for received emails seems to have similar structure (shares `notificationType`, `mail`; in addition has `receipt` and optionally `content`).