### PR TITLE
Fix (*Bucket)PutCopy bugs

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -344,7 +344,7 @@ func (b *Bucket) Put(path string, data []byte, contType string, perm ACL, option
 func (b *Bucket) PutCopy(path string, perm ACL, options CopyOptions, source string) (*CopyObjectResult, error) {
 	headers := map[string][]string{
 		"x-amz-acl":         {string(perm)},
-		"x-amz-copy-source": {url.QueryEscape(source)},
+		"x-amz-copy-source": {escapePath(source)},
 	}
 	options.addHeaders(headers)
 	req := &request{
@@ -1301,4 +1301,8 @@ func shouldRetry(err error) bool {
 func hasCode(err error, code string) bool {
 	s3err, ok := err.(*Error)
 	return ok && s3err.Code == code
+}
+
+func escapePath(s string) string {
+	return (&url.URL{Path: s}).String()
 }

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -264,7 +264,7 @@ func (s *S) TestPutCopy(c *check.C) {
 	c.Assert(req.URL.Path, check.Equals, "/bucket/name")
 	c.Assert(req.Header["Date"], check.Not(check.DeepEquals), []string{""})
 	c.Assert(req.Header["Content-Length"], check.DeepEquals, []string{"0"})
-	c.Assert(req.Header["X-Amz-Copy-Source"], check.DeepEquals, []string{`source-bucket%2F%C3%BCber-fil%C3%A9.jpg`})
+	c.Assert(req.Header["X-Amz-Copy-Source"], check.DeepEquals, []string{`source-bucket/%C3%BCber-fil%C3%A9.jpg`})
 	c.Assert(req.Header["X-Amz-Acl"], check.DeepEquals, []string{"private"})
 }
 

--- a/s3/s3i_test.go
+++ b/s3/s3i_test.go
@@ -185,6 +185,15 @@ func (s *ClientTests) TestBasicFunctionality(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer b.Del("name2")
 
+	result, err := b.PutCopy("name2copy", s3.Private, s3.CopyOptions{
+		ContentType:       "text/plain",
+		MetadataDirective: "REPLACE",
+	}, b.Name+"/name2")
+	c.Assert(err, check.IsNil)
+	_, err = time.Parse(time.RFC3339, result.LastModified)
+	c.Check(err, check.IsNil)
+	defer b.Del("name2copy")
+
 	rc, err := b.GetReader("name2")
 	c.Assert(err, check.IsNil)
 	data, err = ioutil.ReadAll(rc)
@@ -214,6 +223,8 @@ func (s *ClientTests) TestBasicFunctionality(c *check.C) {
 	err = b.Del("name")
 	c.Assert(err, check.IsNil)
 	err = b.Del("name2")
+	c.Assert(err, check.IsNil)
+	err = b.Del("name2copy")
 	c.Assert(err, check.IsNil)
 
 	err = b.DelBucket()


### PR DESCRIPTION
Adds a PutCopy() to the basic functionality test case, and fixes a couple of bugs needed to make it work.
* s3test was sending an empty response body instead of a CopyObjectResult
* PutCopy was using `url.QueryEscape()` to escape the source parameter, which caused the `/` separator to be incorrectly encoded as `%2F`
