### PR TITLE
fix signing of URLs with query parameters with empty value

### DIFF
--- a/aws/sign.go
+++ b/aws/sign.go
@@ -316,12 +316,8 @@ func (s *V4Signer) canonicalQueryString(u *url.URL) string {
 
 		a := make([]string, len(vs))
 		for idx, v := range vs {
-			if v == "" {
-				a[idx] = k
-			} else {
-				v = url.QueryEscape(v)
-				a[idx] = fmt.Sprintf("%s=%s", k, v)
-			}
+			v = url.QueryEscape(v)
+			a[idx] = fmt.Sprintf("%s=%s", k, v)
 		}
 
 		keyValues[k] = strings.Join(a, "&")

--- a/aws/sign_test.go
+++ b/aws/sign_test.go
@@ -341,6 +341,21 @@ func (s *V4SignerSuite) SetUpSuite(c *check.C) {
 			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=f1498ddb4d6dae767d97c466fb92f1b59a2c71ca29ac954692663f9db03426fb",
 		},
 
+		// get-query-empty-value
+		V4SignerSuiteCase{
+			label: "get-vanilla-query-empty-value",
+			request: V4SignerSuiteCaseRequest{
+				method:  "GET",
+				host:    "host.foo.com",
+				url:     "/?a=&b=",
+				headers: []string{"Date:Mon, 09 Sep 2011 23:36:00 GMT"},
+			},
+			canonicalRequest: "GET\n/\na=&b=\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ndate;host\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			stringToSign:     "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/host/aws4_request\n1e51e772d6e4ab0fe63a5a8252bc2a0342d2c96502378964fc91225d0c69066b",
+			signature:        "59b7488da7a50ec99b0342f28df3747f0946870cd97a1a17ce8c849b26c3b0a8",
+			authorization:    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=59b7488da7a50ec99b0342f28df3747f0946870cd97a1a17ce8c849b26c3b0a8",
+		},
+
 		// get-vanilla-query
 		V4SignerSuiteCase{
 			label: "get-vanilla-query",


### PR DESCRIPTION
this fixes V4 signing of URLs with query parameters with an empty value. (from #422)

From the [AWS Documentation](http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html):
> For each parameter, append the URI-encoded parameter name, followed by the character '=' (ASCII code 61), followed by the URI-encoded parameter value. Use an empty string for parameters that have no value.

