### PR TITLE
Fix zeroing existing data when copying an object to itself

### DIFF
--- a/s3/s3i_test.go
+++ b/s3/s3i_test.go
@@ -194,6 +194,13 @@ func (s *ClientTests) TestBasicFunctionality(c *check.C) {
 	c.Check(err, check.IsNil)
 	defer b.Del("name2copy")
 
+	// copying name2->name2 should leave data intact
+	_, err = b.PutCopy("name2", s3.Private, s3.CopyOptions{
+		ContentType:       "text/plain",
+		MetadataDirective: "REPLACE",
+	}, b.Name+"/name2")
+	c.Check(err, check.IsNil)
+
 	rc, err := b.GetReader("name2")
 	c.Assert(err, check.IsNil)
 	data, err = ioutil.ReadAll(rc)

--- a/s3/s3test/server.go
+++ b/s3/s3test/server.go
@@ -827,17 +827,19 @@ func (objr objectResource) put(a *action) interface{} {
 				fatalf(404, "NoSuchKey", "The specified source key does not exist")
 			}
 
-			obj.data = make([]byte, len(sourceObject.data))
-			copy(obj.data, sourceObject.data)
+			if obj != sourceObject {
+				obj.data = make([]byte, len(sourceObject.data))
+				copy(obj.data, sourceObject.data)
 
-			obj.checksum = make([]byte, len(sourceObject.checksum))
-			copy(obj.checksum, sourceObject.checksum)
+				obj.checksum = make([]byte, len(sourceObject.checksum))
+				copy(obj.checksum, sourceObject.checksum)
 
-			obj.meta = make(http.Header, len(sourceObject.meta))
+				obj.meta = make(http.Header, len(sourceObject.meta))
 
-			for k, v := range sourceObject.meta {
-				obj.meta[k] = make([]string, len(v))
-				copy(obj.meta[k], v)
+				for k, v := range sourceObject.meta {
+					obj.meta[k] = make([]string, len(v))
+					copy(obj.meta[k], v)
+				}
 			}
 
 			res = &s3.CopyObjectResult{


### PR DESCRIPTION
Makes s3test do what AWS does in this situation, i.e., update LastModified but leave the data intact.