### PR TITLE
add token signing on aws

### DIFF
--- a/aws/sign.go
+++ b/aws/sign.go
@@ -214,6 +214,9 @@ func (s *V4Signer) Sign(req *http.Request) {
 	} else {
 		req.Header.Set("Authorization", auth) // Add Authorization header to request
 	}
+	if s.auth.Token() != "" {
+		req.Header.Set("X-Amz-Security-Token", s.auth.Token())
+	}
 	return
 }
 


### PR DESCRIPTION
This resolves an issue where the aws signing service didn't account for refreshing and using a token.

This is related to #111 