### PR TITLE
Update .travis.yml to check compatibility with Go 1.8 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: go
 
 go:
-  - 1.2
-  - 1.3.3
-  - 1.4.2
-  - 1.5
-  - tip
+  - 1.2.x
+  - 1.3.x
+  - 1.4.x
+  - 1.5.x
+  - 1.7.x
+  - master
 
 after_script:
   - FIXIT=$(go fmt ./...); if [ -n "${FIXIT}" ]; then FIXED=$(echo $FIXIT | wc -l); echo "gofmt - ${FIXED} file(s) not formatted correctly, please run gofmt to fix them:\n ${FIXIT} " && exit 1; fi


### PR DESCRIPTION
update `travis.yml` to match Travis docs at https://docs.travis-ci.com/user/languages/go 
also to check if we are ok with the soon to be released: `go 1.8`