### PR TITLE
Adding S3 API methods GetACL + GetCannedPolicyByAcl for getting ACL from bucket and object

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -278,7 +278,6 @@ func (b *Bucket) GetReaderWithHeaders(path string) (rc io.ReadCloser, header htt
 	return nil, nil, err
 }
 
-
 // GetReader retrieves an object from an S3 bucket,
 // returning the body of the HTTP response.
 // It is the caller's responsibility to call Close on rc when

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -197,6 +197,35 @@ func (b *Bucket) PutBucket(perm ACL) error {
 	return b.S3.query(req, nil)
 }
 
+// GetACL for getting ACL from bucket or object
+//
+// See http://amzn.to/2rNtK51
+func (b *Bucket) GetACL(key string) (*AccessControlList, error) {
+	headers := map[string][]string{
+		"Content-Length": {strconv.FormatInt(0, 10)},
+	}
+	req := &request{
+		method:  "GET",
+		bucket:  b.Name,
+		path:    "/" + key,
+		headers: headers,
+		payload: b.locationConstraint(),
+		params:  url.Values{"acl": {""}},
+	}
+	var err error
+	resp := &AccessControlList{}
+	for attempt := attempts.Start(); attempt.Next(); {
+		err = b.S3.query(req, resp)
+		if !shouldRetry(err) {
+			break
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 // DelBucket removes an existing S3 bucket. All objects in the bucket must
 // be removed before the bucket itself can be removed.
 //
@@ -228,6 +257,27 @@ func (b *Bucket) Get(path string) (data []byte, err error) {
 	body.Close()
 	return data, err
 }
+
+// GetWithHeaders retrieves an object with headers from an S3 bucket.
+func (b *Bucket) GetWithHeaders(path string) (data []byte, header http.Header, err error) {
+	body, header, err := b.GetReaderWithHeaders(path)
+	if err != nil {
+		return nil, header, err
+	}
+	data, err = ioutil.ReadAll(body)
+	body.Close()
+	return data, header, err
+}
+
+// GetReaderWithHeaders retrieves an object with headers from an S3 bucket
+func (b *Bucket) GetReaderWithHeaders(path string) (rc io.ReadCloser, header http.Header, err error) {
+	resp, err := b.GetResponse(path)
+	if resp != nil {
+		return resp.Body, resp.Header, err
+	}
+	return nil, nil, err
+}
+
 
 // GetReader retrieves an object from an S3 bucket,
 // returning the body of the HTTP response.

--- a/s3/s3aclxml.go
+++ b/s3/s3aclxml.go
@@ -1,0 +1,60 @@
+package s3
+
+import "encoding/xml"
+
+const AllUsersUri = "http://acs.amazonaws.com/groups/global/AllUsers"
+
+type Grantee struct {
+	XMLName     xml.Name `xml:"Grantee"`
+	Type        string   `xml:"type,attr"`
+	URI         string   `xml:"URI"`
+	ID          string   `xml:"ID"`
+	DisplayName string   `xml:"DisplayName"`
+}
+
+type Grant struct {
+	XMLName    xml.Name `xml:"Grant"`
+	Grantee    []Grantee
+	Permission string `xml:"Permission"`
+}
+type AccessControlListGrants struct {
+	XMLName xml.Name `xml:"AccessControlList"`
+	Grant   []Grant
+}
+
+type AclOwner struct {
+	XMLName     xml.Name `xml:"Owner"`
+	ID          string   `xml:"ID"`
+	DisplayName string   `xml:"DisplayName"`
+}
+
+type AccessControlList struct {
+	Owner  AclOwner
+	Grants AccessControlListGrants
+}
+
+func ParseAclFromXml(aclxml string) (AccessControlList, error) {
+	b := []byte(aclxml)
+
+	var acl AccessControlList
+	err := xml.Unmarshal(b, &acl)
+	if err != nil {
+		return acl, err
+	}
+
+	return acl, nil
+}
+
+func GetCannedPolicyByAcl(acl AccessControlList) ACL {
+	for _, grant := range acl.Grants.Grant {
+		//fmt.Printf("Permission: %q\n", grant.Permission)
+		//fmt.Printf("Grantee Type: %q\n", grant.Grantee[0].URI)
+		for _, gratee := range grant.Grantee {
+			if gratee.URI == AllUsersUri {
+				return PublicRead
+			}
+		}
+	}
+
+	return Private
+}

--- a/s3/s3aclxml_test.go
+++ b/s3/s3aclxml_test.go
@@ -1,0 +1,117 @@
+package s3_test
+
+import (
+	"errors"
+
+	"github.com/AdRoll/goamz/s3"
+	"gopkg.in/check.v1"
+)
+
+const xmlResponseSimple = `<?xml version="1.0" encoding="UTF-8"?>
+<AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+<Owner>
+	<ID>owner1</ID>
+	<DisplayName>My service user</DisplayName>
+</Owner>
+
+<AccessControlList>
+<Grant>
+	<Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Group">
+	<URI>http://acs.amazonaws.com/groups/global/AllUsers</URI>
+	</Grantee>
+	<Permission>READ</Permission>
+</Grant>
+
+<Grant>
+	<Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
+	<ID>owner1</ID>
+	<DisplayName>My service user</DisplayName>
+	</Grantee>
+	<Permission>FULL_CONTROL</Permission>
+</Grant>
+
+</AccessControlList>
+</AccessControlPolicy>
+`
+
+const xmlResponseExtended = `<?xml version="1.0" encoding="UTF-8"?>
+<AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+<Owner>
+<ID>Owner-canonical-user-ID</ID>
+<DisplayName>display-name</DisplayName>
+</Owner>
+<AccessControlList>
+<Grant>
+<Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
+<ID>Owner-canonical-user-ID</ID>
+<DisplayName>display-name</DisplayName>
+</Grantee>
+<Permission>FULL_CONTROL</Permission>
+</Grant>
+
+<Grant>
+<Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
+<ID>user1-canonical-user-ID</ID>
+<DisplayName>display-name</DisplayName>
+</Grantee>
+<Permission>WRITE</Permission>
+</Grant>
+
+<Grant>
+<Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
+<ID>user2-canonical-user-ID</ID>
+<DisplayName>display-name</DisplayName>
+</Grantee>
+<Permission>READ</Permission>
+</Grant>
+
+<Grant>
+<Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Group">
+<URI>http://acs.amazonaws.com/groups/global/AllUsers</URI>
+</Grantee>
+<Permission>READ</Permission>
+</Grant>
+<Grant>
+<Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Group">
+<URI>http://acs.amazonaws.com/groups/s3/LogDelivery</URI>
+</Grantee>
+<Permission>WRITE</Permission>
+</Grant>
+
+</AccessControlList>
+</AccessControlPolicy>`
+
+func (s *S) TestShouldParseXmlSimpleACLResponse(c *check.C) {
+	acl, err := s3.ParseAclFromXml(xmlResponseSimple)
+
+	c.Assert(err, check.Equals, nil)
+	c.Assert(acl.Owner.ID, check.Equals, "owner1")
+	c.Assert(acl.Owner.DisplayName, check.Equals, "My service user")
+	c.Assert(acl.Grants.Grant[0].Grantee[0].Type, check.Equals, "Group")
+	c.Assert(acl.Grants.Grant[0].Permission, check.Equals, "READ")
+}
+
+func (s *S) TestShouldParseXmlExtendedACLResponse(c *check.C) {
+	acl, err := s3.ParseAclFromXml(xmlResponseExtended)
+
+	c.Assert(err, check.Equals, nil)
+	c.Assert(acl.Owner.ID, check.Equals, "Owner-canonical-user-ID")
+	c.Assert(acl.Owner.DisplayName, check.Equals, "display-name")
+	c.Assert(acl.Grants.Grant[0].Grantee[0].Type, check.Equals, "CanonicalUser")
+	c.Assert(acl.Grants.Grant[0].Permission, check.Equals, "FULL_CONTROL")
+}
+
+func (s *S) TestShouldNotGetCannedPolicyByAclWithEmptyXmlInput(c *check.C) {
+	_, err := s3.ParseAclFromXml("")
+
+	c.Assert(err, check.DeepEquals, errors.New("EOF"))
+}
+
+func (s *S) TestShouldGetCannedPolicyByAclFromXmlSimpleResponse(c *check.C) {
+	acl, _ := s3.ParseAclFromXml(xmlResponseSimple)
+
+	cannedPolicy := s3.GetCannedPolicyByAcl(acl)
+
+	c.Assert(cannedPolicy, check.Equals, s3.ACL(s3.PublicRead))
+}


### PR DESCRIPTION
In some cases in https://github.com/allegro/akubra supporting tool we need two methods:

- `GetACL` from bucket and objects
- `GetCannedPolicyByAcl` based on results from `GetACL` method for checking permissions in bucket/object

It's important part to developing our next Open Source solution.
This is my proposal of solution for below functionality and new features in S3 `goamz` package.
Please comment and testing my code. 