### PR TITLE
fix Table.GetItem does not support bool type

### DIFF
--- a/dynamodb/item.go
+++ b/dynamodb/item.go
@@ -446,6 +446,14 @@ func parseAttributes(s map[string]interface{}) map[string]*Attribute {
 				attr.Name = key
 				results[key] = attr
 			}
+		case bool:
+			attr := &Attribute{
+				Type:  TYPE_BOOL,
+				Value: strconv.FormatBool(v.(bool)),
+			}
+			if attr.Value != "" {
+				results[key] = attr
+			}
 		}
 	}
 	return results


### PR DESCRIPTION
I added a bool case to the parseAttributes func. This may handle boolean values correctly in boolean key-value pairs.