### PR TITLE
fix [S3] PutCopy not passing Content-Type

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -399,10 +399,11 @@ func (b *Bucket) Put(path string, data []byte, contType string, perm ACL, option
 }
 
 // PutCopy puts a copy of an object given by the key path into bucket b using b.Path as the target key
-func (b *Bucket) PutCopy(path string, perm ACL, options CopyOptions, source string) (*CopyObjectResult, error) {
+func (b *Bucket) PutCopy(path string, perm ACL, options CopyOptions, source string, contentType string) (*CopyObjectResult, error) {
 	headers := map[string][]string{
 		"x-amz-acl":         {string(perm)},
 		"x-amz-copy-source": {escapePath(source)},
+		"Content-Type":      {contentType},
 	}
 	options.addHeaders(headers)
 	req := &request{


### PR DESCRIPTION
I added a new contentType string to the PutCopy func in s3 and in headers map. This may fix the problem.
#198